### PR TITLE
Update azure-stack-validate-pki-certs.md

### DIFF
--- a/azure-stack/operator/azure-stack-validate-pki-certs.md
+++ b/azure-stack/operator/azure-stack-validate-pki-certs.md
@@ -71,7 +71,7 @@ Use these steps to prepare and to validate the Azure Stack PKI certificates for 
     ```powershell  
     New-Item C:\Certificates -ItemType Directory
     
-    $directories = 'ACSBlob', 'ACSQueue', 'ACSTable', 'Admin Extension Host', 'Admin Portal', 'api_appservice', 'ARM Admin', 'ARM Public', 'ftp_appservice', 'KeyVault', 'KeyVaultInternal', 'Public Extension Host', 'Public Portal', 'sso_appservice', 'wildcard_dbadapter', 'wildcard_sso_appservice'
+    $directories = 'ACSBlob', 'ACSQueue', 'ACSTable', 'Admin Extension Host', 'Admin Portal', 'ARM Admin', 'ARM Public', 'KeyVault', 'KeyVaultInternal', 'Public Extension Host', 'Public Portal'
     
     $destination = 'c:\certificates'
     
@@ -82,7 +82,7 @@ Use these steps to prepare and to validate the Azure Stack PKI certificates for 
     > AD FS and Graph are required if you are using AD FS as your identity system. For example:
     >
     > ```powershell  
-    > $directories = 'ACSBlob', 'ACSQueue', 'ACSTable', 'ADFS', 'Admin Extension Host', 'Admin Portal', 'api_appservice', 'ARM Admin', 'ARM Public', 'ftp_appservice', 'Graph', 'KeyVault', 'KeyVaultInternal', 'Public Extension Host', 'Public Portal', 'sso_appservice', 'wildcard_dbadapter', 'wildcard_sso_appservice'
+    > $directories = 'ACSBlob', 'ACSQueue', 'ACSTable', 'ADFS', 'Admin Extension Host', 'Admin Portal', 'ARM Admin', 'ARM Public',  'Graph', 'KeyVault', 'KeyVaultInternal', 'Public Extension Host', 'Public Portal'
     > ```
     
      - Place your certificate(s) in the appropriate directories created in the previous step. For example:  

--- a/azure-stack/operator/azure-stack-validate-pki-certs.md
+++ b/azure-stack/operator/azure-stack-validate-pki-certs.md
@@ -82,7 +82,7 @@ Use these steps to prepare and to validate the Azure Stack PKI certificates for 
     > AD FS and Graph are required if you are using AD FS as your identity system. For example:
     >
     > ```powershell  
-    > $directories = 'ACSBlob', 'ACSQueue', 'ACSTable', 'ADFS', 'Admin Extension Host', 'Admin Portal', 'ARM Admin', 'ARM Public',  'Graph', 'KeyVault', 'KeyVaultInternal', 'Public Extension Host', 'Public Portal'
+    > $directories = 'ACSBlob', 'ACSQueue', 'ACSTable', 'ADFS', 'Admin Extension Host', 'Admin Portal', 'ARM Admin', 'ARM Public', 'Graph', 'KeyVault', 'KeyVaultInternal', 'Public Extension Host', 'Public Portal'
     > ```
     
      - Place your certificate(s) in the appropriate directories created in the previous step. For example:  


### PR DESCRIPTION
The following error raises when Invoke-AzsCertificateValidation validates the certificate of IaaS. I believe that the folders for Paas aren't needed in the validation for the certificate of IaaS.

```
PS C:\Users\AzureStackAdmin\0420> Invoke-AzsCertificateValidation -CertificatePath c:\certificates -pfxPassword $pfxPass
word -RegionName east -FQDN azurestack.contoso.com -IdentitySystem AAD
Invoke-AzsCertificateValidation v1.1811.1101.1 started.
Test-AzsCertificateFolderStructure : Invalid folder structure found in certificate folder c:\certificates, ensure only
required folders are present.
Required folders: ACSBlob, ACSQueue, ACSTable, Admin Portal, ARM Admin, ARM Public, KeyVault, KeyVaultInternal, Public
Portal, Admin Extension Host, Public Extension Host
Invalid folders: api_appservice, ftp_appservice, sso_appservice, wildcard_dbadapter, wildcard_sso_appservice
Missing folders: [none]
At C:\Program Files\WindowsPowerShell\Modules\Microsoft.AzureStack.ReadinessChecker\1.1811.1101.1\CertificateValidation
\Microsoft.AzureStack.CertificateValidation.psm1:257 char:9
+         Test-AzsCertificateFolderStructure -UseADFS:$UseADFS -certifi ...
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
    + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException,Test-AzsCertificateFolderStructure
```