### PR TITLE
Supported version of RHEL

### DIFF
--- a/azure-stack/operator/azure-stack-supported-os.md
+++ b/azure-stack/operator/azure-stack-supported-os.md
@@ -61,7 +61,7 @@ Linux distributions listed as available in the Marketplace include the necessary
 | Container Linux |  64-bit | CoreOS | Stable |
 | Debian 8 "Jessie" | 64-bit | credativ |  Yes |
 | Debian 9 "Stretch" | 64-bit | credativ | Yes |
-| Red Hat Enterprise Linux 7.x | 64-bit | Red Hat |Bring your own image |
+| Red Hat Enterprise Linux 7.1 (and later) | 64-bit | Red Hat |Bring your own image |
 | SLES 11SP4 | 64-bit | SUSE | Yes |
 | SLES 12SP3 | 64-bit | SUSE | Yes |
 | Ubuntu 14.04-LTS | 64-bit | Canonical | Yes |


### PR DESCRIPTION
According to Red Hat doc, RHEL supported version on Azure Stack is  "7.1 (and later)".
https://access.redhat.com/articles/3413531
The expression "7.x" gives the misconception that RHEL 7.0 is supported on Azure Stack.