### PR TITLE
duplicate item

### DIFF
--- a/azure-stack/operator/compare-azure-azure-stack.md
+++ b/azure-stack/operator/compare-azure-azure-stack.md
@@ -55,7 +55,6 @@ In addition to the resource providers described above, there are additional PaaS
 
 - Service Fabric
 - Kubernetes Container Service
-- IoT Hub and Event Hubs
 - Ethereum Blockchain
 - Cloud Foundry
 


### PR DESCRIPTION
"Azure IoT Hub and Event Hubs" is listed in both PaaS list above and template-based solutions. "Azure IoT Hub and Event Hubs" is not template-based solution.