### PR TITLE
Fix azs 1.7.2 modules install

### DIFF
--- a/azure-stack/asdk/asdk-post-deploy.md
+++ b/azure-stack/asdk/asdk-post-deploy.md
@@ -142,7 +142,7 @@ The tests take a few minutes to complete. If the installation was successful, th
 
 If there was a failure, follow the troubleshooting steps to get help.
 
-## Reset the password expiration policy 
+## Reset the password expiration policy
 
 To make sure that the password for the development kit host doesn't expire before your evaluation period ends, follow these steps after you deploy the ASDK.
 

--- a/azure-stack/asdk/asdk-post-deploy.md
+++ b/azure-stack/asdk/asdk-post-deploy.md
@@ -69,7 +69,7 @@ You can install the latest Azure Stack PowerShell module with or without Interne
   - Azure Stack 1811:
 
     ``` PowerShell
-    # Install the AzureRM.BootStrapper module. Select Yes when prompted to install NuGet. 
+    # Install the AzureRM.BootStrapper module. Select Yes when prompted to install NuGet.
     Install-Module -Name AzureRM.BootStrapper
 
     # Install and import the API Version Profile required by Azure Stack into the current PowerShell session.

--- a/azure-stack/asdk/asdk-post-deploy.md
+++ b/azure-stack/asdk/asdk-post-deploy.md
@@ -51,7 +51,6 @@ You can install the latest Azure Stack PowerShell module with or without Interne
       Install-Module -Name AzureRM.BootStrapper
       
       # Install and import the API Version Profile required by Azure Stack into the current PowerShell session.
-      Get-AzureRMProfile -Update
       Use-AzureRmProfile -Profile 2019-03-01-hybrid -Force
       Install-Module -Name AzureStack -RequiredVersion 1.7.2
     ```
@@ -60,7 +59,7 @@ You can install the latest Azure Stack PowerShell module with or without Interne
 
     ```powershell
     # Install and import the API Version Profile required by Azure Stack into the current PowerShell session.
-    Install-Module AzureRM -RequiredVersion 2.4.0
+    Install-Module -Name AzureRM -RequiredVersion 2.4.0
     Install-Module -Name AzureStack -RequiredVersion 1.7.1
     ```
 

--- a/azure-stack/asdk/asdk-post-deploy.md
+++ b/azure-stack/asdk/asdk-post-deploy.md
@@ -49,7 +49,7 @@ You can install the latest Azure Stack PowerShell module with or without Interne
     ```powershell  
       # Install the AzureRM.BootStrapper module. Select Yes when prompted to install NuGet
       Install-Module -Name AzureRM.BootStrapper
-      
+
       # Install and import the API Version Profile required by Azure Stack into the current PowerShell session.
       Use-AzureRmProfile -Profile 2019-03-01-hybrid -Force
       Install-Module -Name AzureStack -RequiredVersion 1.7.2

--- a/azure-stack/asdk/asdk-post-deploy.md
+++ b/azure-stack/asdk/asdk-post-deploy.md
@@ -23,7 +23,7 @@ ms.lastreviewed: 10/10/2018
 
 # Post ASDK installation configuration tasks
 
-After [installing the Azure Stack Development Kit (ASDK)](asdk-install.md), you should make a few recommended post-installation configuration changes while signed in as AzureStack\AzureStackAdmin on the ASDK host computer. 
+After [installing the Azure Stack Development Kit (ASDK)](asdk-install.md), you should make a few recommended post-installation configuration changes while signed in as AzureStack\AzureStackAdmin on the ASDK host computer.
 
 ## Install Azure Stack PowerShell
 

--- a/azure-stack/asdk/asdk-post-deploy.md
+++ b/azure-stack/asdk/asdk-post-deploy.md
@@ -121,7 +121,7 @@ You can install the latest Azure Stack PowerShell module with or without Interne
     -OutFile master.zip
 
   # Expand the downloaded files.
-  Expand-Archive master.zip -DestinationPath . -Force
+  Expand-Archive -Path master.zip -DestinationPath . -Force
 
   # Change to the tools directory.
   cd AzureStack-Tools-master

--- a/azure-stack/asdk/asdk-post-deploy.md
+++ b/azure-stack/asdk/asdk-post-deploy.md
@@ -35,7 +35,7 @@ PowerShell commands for Azure Stack are installed through the PowerShell Gallery
 Set-PSRepository -Name "PSGallery" -InstallationPolicy Trusted
 ```
 
-You can use API version profiles  to specify Azure Stack compatible AzureRM modules.  API version profiles provide a way to manage version differences between Azure and Azure Stack. An API version profile is a set of AzureRM PowerShell modules with specific API versions. The **AzureRM.Bootstrapper** module that is available through the PowerShell Gallery provides PowerShell cmdlets that are required to work with API version profiles.
+You can use API version profiles  to specify Azure Stack compatible AzureRM modules.  API version profiles provide a way to manage version differences between Azure and Azure Stack. An API version profile is a set of AzureRM PowerShell modules with specific API versions. The **AzureRM.BootStrapper** module that is available through the PowerShell Gallery provides PowerShell cmdlets that are required to work with API version profiles.
 
 You can install the latest Azure Stack PowerShell module with or without Internet connectivity to the ASDK host computer:
 
@@ -69,7 +69,7 @@ You can install the latest Azure Stack PowerShell module with or without Interne
   - Azure Stack 1811:
 
     ``` PowerShell
-    # Install the AzureRM.Bootstrapper module. Select Yes when prompted to install NuGet. 
+    # Install the AzureRM.BootStrapper module. Select Yes when prompted to install NuGet. 
     Install-Module -Name AzureRM.BootStrapper
 
     # Install and import the API Version Profile required by Azure Stack into the current PowerShell session.

--- a/azure-stack/asdk/asdk-post-deploy.md
+++ b/azure-stack/asdk/asdk-post-deploy.md
@@ -117,7 +117,7 @@ You can install the latest Azure Stack PowerShell module with or without Interne
   # Enforce usage of TLSv1.2 to download the Azure Stack tools archive from GitHub
   [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
   Invoke-WebRequest `
-    https://github.com/Azure/AzureStack-Tools/archive/master.zip `
+    -Uri https://github.com/Azure/AzureStack-Tools/archive/master.zip `
     -OutFile master.zip
 
   # Expand the downloaded files.

--- a/azure-stack/asdk/asdk-post-deploy.md
+++ b/azure-stack/asdk/asdk-post-deploy.md
@@ -70,7 +70,7 @@ You can install the latest Azure Stack PowerShell module with or without Interne
 
     ``` PowerShell
     # Install the AzureRM.Bootstrapper module. Select Yes when prompted to install NuGet. 
-    Install-Module -Name AzureRm.BootStrapper
+    Install-Module -Name AzureRM.BootStrapper
 
     # Install and import the API Version Profile required by Azure Stack into the current PowerShell session.
     Use-AzureRmProfile -Profile 2018-03-01-hybrid -Force
@@ -116,12 +116,12 @@ You can install the latest Azure Stack PowerShell module with or without Interne
 
   # Enforce usage of TLSv1.2 to download the Azure Stack tools archive from GitHub
   [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-  invoke-webrequest `
+  Invoke-WebRequest `
     https://github.com/Azure/AzureStack-Tools/archive/master.zip `
     -OutFile master.zip
 
   # Expand the downloaded files.
-  expand-archive master.zip -DestinationPath . -Force
+  Expand-Archive master.zip -DestinationPath . -Force
 
   # Change to the tools directory.
   cd AzureStack-Tools-master

--- a/azure-stack/operator/azure-stack-powershell-install.md
+++ b/azure-stack/operator/azure-stack-powershell-install.md
@@ -116,11 +116,11 @@ Run the following PowerShell script to install these modules on your development
 
     > [!Note]  
     > - The Azure Stack module version 1.7.1 is a breaking change release. To migrate from Azure Stack 1.6.0 please refer to the [migration guide](https://aka.ms/azspshmigration171).
-    > - The AzureRm module version 2.4.0 comes with a breaking change for the cmdlet Remove-AzureRmStorageAccount. This cmdlet expects -Force parameter to be specified for removing the storage account without confirmation.
-    > - You don't need to install **AzureRM.Bootstrapper** to install the modules for Azure Stack version 1901 or later.
+    > - The AzureRM module version 2.4.0 comes with a breaking change for the cmdlet Remove-AzureRmStorageAccount. This cmdlet expects -Force parameter to be specified for removing the storage account without confirmation.
+    > - You don't need to install **AzureRM.BootStrapper** to install the modules for Azure Stack version 1901 or later.
     > - Don't install the 2018-03-01-hybrid profile in addition to using the above AzureRM modules on Azure Stack version 1901 or later.
 
-- Azure Stack version 1811, install the profile using **AzureRM.Bootstrapper**, in addition to the versions indicated in the cmdlets:
+- Azure Stack version 1811, install the profile using **AzureRM.BootStrapper**, in addition to the versions indicated in the cmdlets:
 
     ```powershell  
     # Install the AzureRM.BootStrapper module. Select Yes when prompted to install NuGet
@@ -140,7 +140,7 @@ To make use of the additional storage features (mentioned in the connected secti
 # Install the Azure.Storage module version 4.5.0
 Install-Module -Name Azure.Storage -RequiredVersion 4.5.0 -Force -AllowClobber
 
-# Install the AzureRm.Storage module version 5.0.4
+# Install the AzureRM.Storage module version 5.0.4
 Install-Module -Name AzureRM.Storage -RequiredVersion 5.0.4 -Force -AllowClobber
 
 # Remove incompatible storage module installed by AzureRM.Storage

--- a/azure-stack/operator/azure-stack-powershell-install.md
+++ b/azure-stack/operator/azure-stack-powershell-install.md
@@ -117,7 +117,7 @@ Run the following PowerShell script to install these modules on your development
     > [!Note]  
     > - The Azure Stack module version 1.7.1 is a breaking change release. To migrate from Azure Stack 1.6.0 please refer to the [migration guide](https://aka.ms/azspshmigration171).
     > - The AzureRm module version 2.4.0 comes with a breaking change for the cmdlet Remove-AzureRmStorageAccount. This cmdlet expects -Force parameter to be specified for removing the storage account without confirmation.
-    > - You don't need to install **AzureRM.Bootstrapper** to install the modules for Azure stack version 1901 or later.
+    > - You don't need to install **AzureRM.Bootstrapper** to install the modules for Azure Stack version 1901 or later.
     > - Don't install the 2018-03-01-hybrid profile in addition to using the above AzureRM modules on Azure Stack version 1901 or later.
 
 - Azure Stack version 1811, install the profile using **AzureRM.Bootstrapper**, in addition to the versions indicated in the cmdlets:

--- a/azure-stack/operator/azure-stack-powershell-install.md
+++ b/azure-stack/operator/azure-stack-powershell-install.md
@@ -237,7 +237,7 @@ To make use of the additional storage features (mentioned in the connected secti
 ```powershell
 $Path = "<Path that is used to save the packages>"
 Save-Package -ProviderName NuGet -Source https://www.powershellgallery.com/api/v2 -Name Azure.Storage -Path $Path -Force -RequiredVersion 4.5.0
-Save-Package -ProviderName NuGet -Source https://www.powershellgallery.com/api/v2 -Name AzureRm.Storage -Path $Path -Force -RequiredVersion 5.0.4
+Save-Package -ProviderName NuGet -Source https://www.powershellgallery.com/api/v2 -Name AzureRM.Storage -Path $Path -Force -RequiredVersion 5.0.4
 ```
 
 ### Add your packages to your workstation

--- a/azure-stack/operator/azure-stack-powershell-install.md
+++ b/azure-stack/operator/azure-stack-powershell-install.md
@@ -99,7 +99,7 @@ Run the following PowerShell script to install these modules on your development
     ```powershell  
     # Install the AzureRM.BootStrapper module. Select Yes when prompted to install NuGet
     Install-Module -Name AzureRM.BootStrapper
-    
+
     # Install and import the API Version Profile required by Azure Stack into the current PowerShell session.
     Use-AzureRmProfile -Profile 2019-03-01-hybrid -Force
     Install-Module -Name AzureStack -RequiredVersion 1.7.2

--- a/azure-stack/operator/azure-stack-powershell-install.md
+++ b/azure-stack/operator/azure-stack-powershell-install.md
@@ -101,7 +101,6 @@ Run the following PowerShell script to install these modules on your development
     Install-Module -Name AzureRM.BootStrapper
     
     # Install and import the API Version Profile required by Azure Stack into the current PowerShell session.
-    Get-AzureRmProfile -Update
     Use-AzureRmProfile -Profile 2019-03-01-hybrid -Force
     Install-Module -Name AzureStack -RequiredVersion 1.7.2
     ```


### PR DESCRIPTION
With the release of https://www.powershellgallery.com/packages/AzureRM.BootStrapper/0.5.0

Thanks to https://github.com/Azure/azure-powershell/pull/9211 and https://github.com/Azure/azure-powershell/pull/9226 we no longer need to run **Get-AzureRmProfile -Update** because it is part of 0.5.0 module so I removed it from both docs where it was relevant to do so.

Plus fixed params, cases, trailing spaces etc...

How the install should work now: (from fresh Windows Core Docker)

```powershell
Windows PowerShell
Copyright (C) 2016 Microsoft Corporation. All rights reserved.

PS C:\> Remove-Module -Name PSReadline
PS C:\> Install-Module -Name AzureRM.BootStrapper -Verbose

NuGet provider is required to continue
PowerShellGet requires NuGet provider version '2.8.5.201' or newer to interact with NuGet-based repositories. The NuGet provider must be available in 'C:\Program Files\PackageManagement\ProviderAssemblies' or
'C:\Users\ContainerAdministrator\AppData\Local\PackageManagement\ProviderAssemblies'. You can also install the NuGet provider by running 'Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force'. Do you want PowerShellGet to install and import the NuGet
provider now?
[Y] Yes  [N] No  [S] Suspend  [?] Help (default is "Y"): y
VERBOSE: Installing NuGet provider.
VERBOSE: Using the provider 'Bootstrap' for searching packages.
VERBOSE: Finding the package 'Bootstrap::FindPackage' 'NuGet','','2.8.5.201','''.
VERBOSE: Installing the package 'https://onegetcdn.azureedge.net/providers/nuget-2.8.5.208.package.swidtag'.
VERBOSE: Installed the package 'nuget' to 'C:\Program Files\PackageManagement\ProviderAssemblies\nuget\2.8.5.208\Microsoft.PackageManagement.NuGetProvider.dll'.
VERBOSE: Importing the package provider NuGet
VERBOSE: The provider 'NuGet' has already been imported. Trying to import it again.
VERBOSE: Loading an assembly 'C:\Program Files\PackageManagement\ProviderAssemblies\nuget\2.8.5.208\Microsoft.PackageManagement.NuGetProvider.dll'.
VERBOSE: Imported provider 'C:\Program Files\PackageManagement\ProviderAssemblies\nuget\2.8.5.208\Microsoft.PackageManagement.NuGetProvider.dll' .
VERBOSE: The provider 'NuGet' has already been imported. Trying to import it again.
VERBOSE: Importing package provider 'NuGet'.
VERBOSE: Using the provider 'PowerShellGet' for searching packages.
VERBOSE: The -Repository parameter was not specified.  PowerShellGet will use all of the registered repositories.
VERBOSE: Getting the provider object for the PackageManagement Provider 'NuGet'.
VERBOSE: The specified Location is 'https://www.powershellgallery.com/api/v2' and PackageManagementProvider is 'NuGet'.
VERBOSE: Searching repository 'https://www.powershellgallery.com/api/v2/FindPackagesById()?id='AzureRM.BootStrapper'' for ''.
VERBOSE: Total package yield:'1' for the specified package 'AzureRM.BootStrapper'.
VERBOSE: Performing the operation "Install-Module" on target "Version '0.5.0' of module 'AzureRM.BootStrapper'".

Untrusted repository
You are installing the modules from an untrusted repository. If you trust this repository, change its InstallationPolicy value by running the Set-PSRepository cmdlet. Are you sure you want to install the modules from 'PSGallery'?
[Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "N"): a
VERBOSE: The installation scope is specified to be 'AllUsers'.
VERBOSE: The specified module will be installed in 'C:\Program Files\WindowsPowerShell\Modules'.
VERBOSE: The specified Location is 'NuGet' and PackageManagementProvider is 'NuGet'.
VERBOSE: Downloading module 'AzureRM.BootStrapper' with version '0.5.0' from the repository 'https://www.powershellgallery.com/api/v2'.
VERBOSE: Searching repository 'https://www.powershellgallery.com/api/v2/FindPackagesById()?id='AzureRM.BootStrapper'' for ''.
VERBOSE: InstallPackage' - name='AzureRM.BootStrapper', version='0.5.0',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\1020944649'
VERBOSE: DownloadPackage' - name='AzureRM.BootStrapper', version='0.5.0',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\1020944649\AzureRM.BootStrapper\AzureRM.BootStrapper.nupkg',
uri='https://www.powershellgallery.com/api/v2/package/AzureRM.BootStrapper/0.5.0'
VERBOSE: Downloading 'https://www.powershellgallery.com/api/v2/package/AzureRM.BootStrapper/0.5.0'.
VERBOSE: Completed downloading 'https://www.powershellgallery.com/api/v2/package/AzureRM.BootStrapper/0.5.0'.
VERBOSE: Completed downloading 'AzureRM.BootStrapper'.
VERBOSE: Hash for package 'AzureRM.BootStrapper' does not match hash provided from the server.
VERBOSE: InstallPackageLocal' - name='AzureRM.BootStrapper', version='0.5.0',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\1020944649'
VERBOSE: Catalog file 'AzureRM.BootStrapper.cat' is not found in the contents of the module 'AzureRM.BootStrapper' being installed.
VERBOSE: Module 'AzureRM.BootStrapper' was installed successfully to path 'C:\Program Files\WindowsPowerShell\Modules\AzureRM.BootStrapper\0.5.0'.
PS C:\> Use-AzureRmProfile -Profile 2019-03-01-hybrid -Force
Loading Profile 2019-03-01-hybrid

Untrusted repository
You are installing the modules from an untrusted repository. If you trust this repository, change its InstallationPolicy value by running the Set-PSRepository cmdlet. Are you sure you want to install the modules from 'PSGallery'?
[Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "N"): a
PS C:\> Install-Module -Name AzureStack -RequiredVersion 1.7.2 -Verbose
VERBOSE: Using the provider 'PowerShellGet' for searching packages.
VERBOSE: The -Repository parameter was not specified.  PowerShellGet will use all of the registered repositories.
VERBOSE: Getting the provider object for the PackageManagement Provider 'NuGet'.
VERBOSE: The specified Location is 'https://www.powershellgallery.com/api/v2' and PackageManagementProvider is 'NuGet'.
VERBOSE: Searching repository 'https://www.powershellgallery.com/api/v2/FindPackagesById()?id='AzureStack'' for ''.
VERBOSE: Total package yield:'1' for the specified package 'AzureStack'.
VERBOSE: Performing the operation "Install-Module" on target "Version '1.7.2' of module 'AzureStack'".

Untrusted repository
You are installing the modules from an untrusted repository. If you trust this repository, change its InstallationPolicy value by running the Set-PSRepository cmdlet. Are you sure you want to install the modules from 'PSGallery'?
[Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "N"): a
VERBOSE: The installation scope is specified to be 'AllUsers'.
VERBOSE: The specified module will be installed in 'C:\Program Files\WindowsPowerShell\Modules'.
VERBOSE: The specified Location is 'NuGet' and PackageManagementProvider is 'NuGet'.
VERBOSE: Downloading module 'AzureStack' with version '1.7.2' from the repository 'https://www.powershellgallery.com/api/v2'.
VERBOSE: Searching repository 'https://www.powershellgallery.com/api/v2/FindPackagesById()?id='AzureStack'' for ''.
VERBOSE: Package 'AzureRM.Profile' is already installed.
VERBOSE: Package 'AzureRM.Resources' is already installed.
VERBOSE: Searching repository 'https://www.powershellgallery.com/api/v2/FindPackagesById()?id='Azs.AzureBridge.Admin'' for ''.
VERBOSE: Package 'AzureRM.Profile' is already installed.
VERBOSE: Package 'AzureRM.Resources' is already installed.
VERBOSE: Searching repository 'https://www.powershellgallery.com/api/v2/FindPackagesById()?id='Azs.Backup.Admin'' for ''.
VERBOSE: Package 'AzureRM.Profile' is already installed.
VERBOSE: Package 'AzureRM.Resources' is already installed.
VERBOSE: Searching repository 'https://www.powershellgallery.com/api/v2/FindPackagesById()?id='Azs.Commerce.Admin'' for ''.
VERBOSE: Package 'AzureRM.Profile' is already installed.
VERBOSE: Package 'AzureRM.Resources' is already installed.
VERBOSE: Searching repository 'https://www.powershellgallery.com/api/v2/FindPackagesById()?id='Azs.Compute.Admin'' for ''.
VERBOSE: Package 'AzureRM.Profile' is already installed.
VERBOSE: Package 'AzureRM.Resources' is already installed.
VERBOSE: Searching repository 'https://www.powershellgallery.com/api/v2/FindPackagesById()?id='Azs.Fabric.Admin'' for ''.
VERBOSE: Package 'AzureRM.Profile' is already installed.
VERBOSE: Package 'AzureRM.Resources' is already installed.
VERBOSE: Searching repository 'https://www.powershellgallery.com/api/v2/FindPackagesById()?id='Azs.Gallery.Admin'' for ''.
VERBOSE: Package 'AzureRM.Profile' is already installed.
VERBOSE: Package 'AzureRM.Resources' is already installed.
VERBOSE: Searching repository 'https://www.powershellgallery.com/api/v2/FindPackagesById()?id='Azs.InfrastructureInsights.Admin'' for ''.
VERBOSE: Package 'AzureRM.Profile' is already installed.
VERBOSE: Package 'AzureRM.Resources' is already installed.
VERBOSE: Searching repository 'https://www.powershellgallery.com/api/v2/FindPackagesById()?id='Azs.KeyVault.Admin'' for ''.
VERBOSE: Package 'AzureRM.Profile' is already installed.
VERBOSE: Package 'AzureRM.Resources' is already installed.
VERBOSE: Searching repository 'https://www.powershellgallery.com/api/v2/FindPackagesById()?id='Azs.Network.Admin'' for ''.
VERBOSE: Package 'AzureRM.Profile' is already installed.
VERBOSE: Package 'AzureRM.Resources' is already installed.
VERBOSE: Searching repository 'https://www.powershellgallery.com/api/v2/FindPackagesById()?id='Azs.Storage.Admin'' for ''.
VERBOSE: Package 'AzureRM.Profile' is already installed.
VERBOSE: Package 'AzureRM.Resources' is already installed.
VERBOSE: Searching repository 'https://www.powershellgallery.com/api/v2/FindPackagesById()?id='Azs.Subscriptions'' for ''.
VERBOSE: Package 'AzureRM.Profile' is already installed.
VERBOSE: Package 'AzureRM.Resources' is already installed.
VERBOSE: Searching repository 'https://www.powershellgallery.com/api/v2/FindPackagesById()?id='Azs.Subscriptions.Admin'' for ''.
VERBOSE: Package 'AzureRM.Profile' is already installed.
VERBOSE: Package 'AzureRM.Resources' is already installed.
VERBOSE: Searching repository 'https://www.powershellgallery.com/api/v2/FindPackagesById()?id='Azs.Update.Admin'' for ''.
VERBOSE: Package 'AzureRM.Profile' is already installed.
VERBOSE: Package 'AzureRM.Resources' is already installed.
VERBOSE: Package 'AzureRM.Profile' is already installed.
VERBOSE: Package 'AzureRM.Resources' is already installed.
VERBOSE: Package 'AzureRM.Profile' is already installed.
VERBOSE: Package 'AzureRM.Resources' is already installed.
VERBOSE: Package 'AzureRM.Profile' is already installed.
VERBOSE: Package 'AzureRM.Resources' is already installed.
VERBOSE: Package 'AzureRM.Profile' is already installed.
VERBOSE: Package 'AzureRM.Resources' is already installed.
VERBOSE: Package 'AzureRM.Profile' is already installed.
VERBOSE: Package 'AzureRM.Resources' is already installed.
VERBOSE: Package 'AzureRM.Profile' is already installed.
VERBOSE: Package 'AzureRM.Resources' is already installed.
VERBOSE: Package 'AzureRM.Profile' is already installed.
VERBOSE: Package 'AzureRM.Resources' is already installed.
VERBOSE: Package 'AzureRM.Profile' is already installed.
VERBOSE: Package 'AzureRM.Resources' is already installed.
VERBOSE: Package 'AzureRM.Profile' is already installed.
VERBOSE: Package 'AzureRM.Resources' is already installed.
VERBOSE: Package 'AzureRM.Profile' is already installed.
VERBOSE: Package 'AzureRM.Resources' is already installed.
VERBOSE: Package 'AzureRM.Profile' is already installed.
VERBOSE: Package 'AzureRM.Resources' is already installed.
VERBOSE: Package 'AzureRM.Profile' is already installed.
VERBOSE: Package 'AzureRM.Resources' is already installed.
VERBOSE: Package 'AzureRM.Profile' is already installed.
VERBOSE: Package 'AzureRM.Resources' is already installed.
VERBOSE: Package 'AzureRM.Profile' is already installed.
VERBOSE: Package 'AzureRM.Resources' is already installed.
VERBOSE: InstallPackage' - name='Azs.Azurebridge.Admin', version='0.2.2',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566'
VERBOSE: DownloadPackage' - name='Azs.Azurebridge.Admin', version='0.2.2',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566\Azs.Azurebridge.Admin\Azs.Azurebridge.Admin.nupkg',
uri='https://www.powershellgallery.com/api/v2/package/Azs.Azurebridge.Admin/0.2.2'
VERBOSE: Downloading 'https://www.powershellgallery.com/api/v2/package/Azs.Azurebridge.Admin/0.2.2'.
VERBOSE: Completed downloading 'https://www.powershellgallery.com/api/v2/package/Azs.Azurebridge.Admin/0.2.2'.
VERBOSE: Completed downloading 'Azs.Azurebridge.Admin'.
VERBOSE: Hash for package 'Azs.Azurebridge.Admin' does not match hash provided from the server.
VERBOSE: InstallPackageLocal' - name='Azs.Azurebridge.Admin', version='0.2.2',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566'
VERBOSE: InstallPackage' - name='Azs.Backup.Admin', version='0.3.1',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566'
VERBOSE: DownloadPackage' - name='Azs.Backup.Admin', version='0.3.1',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566\Azs.Backup.Admin\Azs.Backup.Admin.nupkg', uri='https://www.powershellgallery.com/api/v2/package/Azs.Backup.Admin/0.3.1'
VERBOSE: Downloading 'https://www.powershellgallery.com/api/v2/package/Azs.Backup.Admin/0.3.1'.
VERBOSE: Completed downloading 'https://www.powershellgallery.com/api/v2/package/Azs.Backup.Admin/0.3.1'.
VERBOSE: Completed downloading 'Azs.Backup.Admin'.
VERBOSE: Hash for package 'Azs.Backup.Admin' does not match hash provided from the server.
VERBOSE: InstallPackageLocal' - name='Azs.Backup.Admin', version='0.3.1',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566'
VERBOSE: Catalog file 'Azs.Azurebridge.Admin.cat' is not found in the contents of the module 'Azs.Azurebridge.Admin' being installed.
VERBOSE: InstallPackage' - name='Azs.Commerce.Admin', version='0.2.2',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566'
VERBOSE: DownloadPackage' - name='Azs.Commerce.Admin', version='0.2.2',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566\Azs.Commerce.Admin\Azs.Commerce.Admin.nupkg', uri='https://www.powershellgallery.com/api/v2/package/Azs.Commerce.Admin/0.2.2'
VERBOSE: Downloading 'https://www.powershellgallery.com/api/v2/package/Azs.Commerce.Admin/0.2.2'.
VERBOSE: Installing the dependency module 'Azs.Azurebridge.Admin' with version '0.2.2' for the module 'AzureStack'.
VERBOSE: Module 'Azs.Azurebridge.Admin' was installed successfully to path 'C:\Program Files\WindowsPowerShell\Modules\Azs.Azurebridge.Admin\0.2.2'.
VERBOSE: Completed downloading 'https://www.powershellgallery.com/api/v2/package/Azs.Commerce.Admin/0.2.2'.
VERBOSE: Completed downloading 'Azs.Commerce.Admin'.
VERBOSE: Hash for package 'Azs.Commerce.Admin' does not match hash provided from the server.
VERBOSE: InstallPackageLocal' - name='Azs.Commerce.Admin', version='0.2.2',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566'
VERBOSE: Catalog file 'Azs.Backup.Admin.cat' is not found in the contents of the module 'Azs.Backup.Admin' being installed.
VERBOSE: InstallPackage' - name='Azs.Compute.Admin', version='0.2.3',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566'
VERBOSE: DownloadPackage' - name='Azs.Compute.Admin', version='0.2.3',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566\Azs.Compute.Admin\Azs.Compute.Admin.nupkg', uri='https://www.powershellgallery.com/api/v2/package/Azs.Compute.Admin/0.2.3'
VERBOSE: Downloading 'https://www.powershellgallery.com/api/v2/package/Azs.Compute.Admin/0.2.3'.
VERBOSE: Installing the dependency module 'Azs.Backup.Admin' with version '0.3.1' for the module 'AzureStack'.
VERBOSE: Module 'Azs.Backup.Admin' was installed successfully to path 'C:\Program Files\WindowsPowerShell\Modules\Azs.Backup.Admin\0.3.1'.
VERBOSE: Completed downloading 'https://www.powershellgallery.com/api/v2/package/Azs.Compute.Admin/0.2.3'.
VERBOSE: Completed downloading 'Azs.Compute.Admin'.
VERBOSE: Hash for package 'Azs.Compute.Admin' does not match hash provided from the server.
VERBOSE: InstallPackageLocal' - name='Azs.Compute.Admin', version='0.2.3',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566'
VERBOSE: Catalog file 'Azs.Commerce.Admin.cat' is not found in the contents of the module 'Azs.Commerce.Admin' being installed.
VERBOSE: InstallPackage' - name='Azs.Fabric.Admin', version='0.4.1',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566'
VERBOSE: DownloadPackage' - name='Azs.Fabric.Admin', version='0.4.1',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566\Azs.Fabric.Admin\Azs.Fabric.Admin.nupkg', uri='https://www.powershellgallery.com/api/v2/package/Azs.Fabric.Admin/0.4.1'
VERBOSE: Downloading 'https://www.powershellgallery.com/api/v2/package/Azs.Fabric.Admin/0.4.1'.
VERBOSE: Installing the dependency module 'Azs.Commerce.Admin' with version '0.2.2' for the module 'AzureStack'.
VERBOSE: Module 'Azs.Commerce.Admin' was installed successfully to path 'C:\Program Files\WindowsPowerShell\Modules\Azs.Commerce.Admin\0.2.2'.
VERBOSE: Completed downloading 'https://www.powershellgallery.com/api/v2/package/Azs.Fabric.Admin/0.4.1'.
VERBOSE: Completed downloading 'Azs.Fabric.Admin'.
VERBOSE: Hash for package 'Azs.Fabric.Admin' does not match hash provided from the server.
VERBOSE: InstallPackageLocal' - name='Azs.Fabric.Admin', version='0.4.1',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566'
VERBOSE: Catalog file 'Azs.Compute.Admin.cat' is not found in the contents of the module 'Azs.Compute.Admin' being installed.
VERBOSE: InstallPackage' - name='Azs.Gallery.Admin', version='0.2.2',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566'
VERBOSE: DownloadPackage' - name='Azs.Gallery.Admin', version='0.2.2',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566\Azs.Gallery.Admin\Azs.Gallery.Admin.nupkg', uri='https://www.powershellgallery.com/api/v2/package/Azs.Gallery.Admin/0.2.2'
VERBOSE: Downloading 'https://www.powershellgallery.com/api/v2/package/Azs.Gallery.Admin/0.2.2'.
VERBOSE: Installing the dependency module 'Azs.Compute.Admin' with version '0.2.3' for the module 'AzureStack'.
VERBOSE: Module 'Azs.Compute.Admin' was installed successfully to path 'C:\Program Files\WindowsPowerShell\Modules\Azs.Compute.Admin\0.2.3'.
VERBOSE: Completed downloading 'https://www.powershellgallery.com/api/v2/package/Azs.Gallery.Admin/0.2.2'.
VERBOSE: Completed downloading 'Azs.Gallery.Admin'.
VERBOSE: Hash for package 'Azs.Gallery.Admin' does not match hash provided from the server.
VERBOSE: InstallPackageLocal' - name='Azs.Gallery.Admin', version='0.2.2',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566'
VERBOSE: Catalog file 'Azs.Fabric.Admin.cat' is not found in the contents of the module 'Azs.Fabric.Admin' being installed.
VERBOSE: InstallPackage' - name='Azs.Infrastructureinsights.Admin', version='0.3.2',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566'
VERBOSE: DownloadPackage' - name='Azs.Infrastructureinsights.Admin', version='0.3.2',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566\Azs.Infrastructureinsights.Admin\Azs.Infrastructureinsights.Admin.nupkg',
uri='https://www.powershellgallery.com/api/v2/package/Azs.Infrastructureinsights.Admin/0.3.2'
VERBOSE: Downloading 'https://www.powershellgallery.com/api/v2/package/Azs.Infrastructureinsights.Admin/0.3.2'.
VERBOSE: Completed downloading 'https://www.powershellgallery.com/api/v2/package/Azs.Infrastructureinsights.Admin/0.3.2'.
VERBOSE: Completed downloading 'Azs.Infrastructureinsights.Admin'.
VERBOSE: Hash for package 'Azs.Infrastructureinsights.Admin' does not match hash provided from the server.
VERBOSE: InstallPackageLocal' - name='Azs.Infrastructureinsights.Admin', version='0.3.2',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566'
VERBOSE: Installing the dependency module 'Azs.Fabric.Admin' with version '0.4.1' for the module 'AzureStack'.
VERBOSE: Module 'Azs.Fabric.Admin' was installed successfully to path 'C:\Program Files\WindowsPowerShell\Modules\Azs.Fabric.Admin\0.4.1'.
VERBOSE: Catalog file 'Azs.Gallery.Admin.cat' is not found in the contents of the module 'Azs.Gallery.Admin' being installed.
VERBOSE: InstallPackage' - name='Azs.Keyvault.Admin', version='0.2.2',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566'
VERBOSE: DownloadPackage' - name='Azs.Keyvault.Admin', version='0.2.2',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566\Azs.Keyvault.Admin\Azs.Keyvault.Admin.nupkg', uri='https://www.powershellgallery.com/api/v2/package/Azs.Keyvault.Admin/0.2.2'
VERBOSE: Downloading 'https://www.powershellgallery.com/api/v2/package/Azs.Keyvault.Admin/0.2.2'.
VERBOSE: Installing the dependency module 'Azs.Gallery.Admin' with version '0.2.2' for the module 'AzureStack'.
VERBOSE: Module 'Azs.Gallery.Admin' was installed successfully to path 'C:\Program Files\WindowsPowerShell\Modules\Azs.Gallery.Admin\0.2.2'.
VERBOSE: Completed downloading 'https://www.powershellgallery.com/api/v2/package/Azs.Keyvault.Admin/0.2.2'.
VERBOSE: Completed downloading 'Azs.Keyvault.Admin'.
VERBOSE: Hash for package 'Azs.Keyvault.Admin' does not match hash provided from the server.
VERBOSE: InstallPackageLocal' - name='Azs.Keyvault.Admin', version='0.2.2',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566'
VERBOSE: Catalog file 'Azs.Infrastructureinsights.Admin.cat' is not found in the contents of the module 'Azs.Infrastructureinsights.Admin' being installed.
VERBOSE: InstallPackage' - name='Azs.Network.Admin', version='0.2.2',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566'
VERBOSE: DownloadPackage' - name='Azs.Network.Admin', version='0.2.2',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566\Azs.Network.Admin\Azs.Network.Admin.nupkg', uri='https://www.powershellgallery.com/api/v2/package/Azs.Network.Admin/0.2.2'
VERBOSE: Downloading 'https://www.powershellgallery.com/api/v2/package/Azs.Network.Admin/0.2.2'.
VERBOSE: Installing the dependency module 'Azs.Infrastructureinsights.Admin' with version '0.3.2' for the module 'AzureStack'.
VERBOSE: Module 'Azs.Infrastructureinsights.Admin' was installed successfully to path 'C:\Program Files\WindowsPowerShell\Modules\Azs.Infrastructureinsights.Admin\0.3.2'.
VERBOSE: Completed downloading 'https://www.powershellgallery.com/api/v2/package/Azs.Network.Admin/0.2.2'.
VERBOSE: Completed downloading 'Azs.Network.Admin'.
VERBOSE: Hash for package 'Azs.Network.Admin' does not match hash provided from the server.
VERBOSE: InstallPackageLocal' - name='Azs.Network.Admin', version='0.2.2',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566'
VERBOSE: Catalog file 'Azs.Keyvault.Admin.cat' is not found in the contents of the module 'Azs.Keyvault.Admin' being installed.
VERBOSE: InstallPackage' - name='Azs.Storage.Admin', version='0.2.3',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566'
VERBOSE: DownloadPackage' - name='Azs.Storage.Admin', version='0.2.3',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566\Azs.Storage.Admin\Azs.Storage.Admin.nupkg', uri='https://www.powershellgallery.com/api/v2/package/Azs.Storage.Admin/0.2.3'
VERBOSE: Downloading 'https://www.powershellgallery.com/api/v2/package/Azs.Storage.Admin/0.2.3'.
VERBOSE: Installing the dependency module 'Azs.Keyvault.Admin' with version '0.2.2' for the module 'AzureStack'.
VERBOSE: Module 'Azs.Keyvault.Admin' was installed successfully to path 'C:\Program Files\WindowsPowerShell\Modules\Azs.Keyvault.Admin\0.2.2'.
VERBOSE: Completed downloading 'https://www.powershellgallery.com/api/v2/package/Azs.Storage.Admin/0.2.3'.
VERBOSE: Completed downloading 'Azs.Storage.Admin'.
VERBOSE: Hash for package 'Azs.Storage.Admin' does not match hash provided from the server.
VERBOSE: InstallPackageLocal' - name='Azs.Storage.Admin', version='0.2.3',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566'
VERBOSE: Catalog file 'Azs.Network.Admin.cat' is not found in the contents of the module 'Azs.Network.Admin' being installed.
VERBOSE: InstallPackage' - name='Azs.Subscriptions', version='0.2.2',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566'
VERBOSE: DownloadPackage' - name='Azs.Subscriptions', version='0.2.2',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566\Azs.Subscriptions\Azs.Subscriptions.nupkg', uri='https://www.powershellgallery.com/api/v2/package/Azs.Subscriptions/0.2.2'
VERBOSE: Downloading 'https://www.powershellgallery.com/api/v2/package/Azs.Subscriptions/0.2.2'.
VERBOSE: Installing the dependency module 'Azs.Network.Admin' with version '0.2.2' for the module 'AzureStack'.
VERBOSE: Module 'Azs.Network.Admin' was installed successfully to path 'C:\Program Files\WindowsPowerShell\Modules\Azs.Network.Admin\0.2.2'.
VERBOSE: Completed downloading 'https://www.powershellgallery.com/api/v2/package/Azs.Subscriptions/0.2.2'.
VERBOSE: Completed downloading 'Azs.Subscriptions'.
VERBOSE: Hash for package 'Azs.Subscriptions' does not match hash provided from the server.
VERBOSE: InstallPackageLocal' - name='Azs.Subscriptions', version='0.2.2',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566'
VERBOSE: Catalog file 'Azs.Storage.Admin.cat' is not found in the contents of the module 'Azs.Storage.Admin' being installed.
VERBOSE: InstallPackage' - name='Azs.Subscriptions.Admin', version='0.3.3',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566'
VERBOSE: DownloadPackage' - name='Azs.Subscriptions.Admin', version='0.3.3',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566\Azs.Subscriptions.Admin\Azs.Subscriptions.Admin.nupkg',
uri='https://www.powershellgallery.com/api/v2/package/Azs.Subscriptions.Admin/0.3.3'
VERBOSE: Downloading 'https://www.powershellgallery.com/api/v2/package/Azs.Subscriptions.Admin/0.3.3'.
VERBOSE: Completed downloading 'https://www.powershellgallery.com/api/v2/package/Azs.Subscriptions.Admin/0.3.3'.
VERBOSE: Completed downloading 'Azs.Subscriptions.Admin'.
VERBOSE: Hash for package 'Azs.Subscriptions.Admin' does not match hash provided from the server.
VERBOSE: InstallPackageLocal' - name='Azs.Subscriptions.Admin', version='0.3.3',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566'
VERBOSE: Installing the dependency module 'Azs.Storage.Admin' with version '0.2.3' for the module 'AzureStack'.
VERBOSE: Module 'Azs.Storage.Admin' was installed successfully to path 'C:\Program Files\WindowsPowerShell\Modules\Azs.Storage.Admin\0.2.3'.
VERBOSE: Catalog file 'Azs.Subscriptions.cat' is not found in the contents of the module 'Azs.Subscriptions' being installed.
VERBOSE: InstallPackage' - name='Azs.Update.Admin', version='0.2.3',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566'
VERBOSE: DownloadPackage' - name='Azs.Update.Admin', version='0.2.3',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566\Azs.Update.Admin\Azs.Update.Admin.nupkg', uri='https://www.powershellgallery.com/api/v2/package/Azs.Update.Admin/0.2.3'
VERBOSE: Downloading 'https://www.powershellgallery.com/api/v2/package/Azs.Update.Admin/0.2.3'.
VERBOSE: Installing the dependency module 'Azs.Subscriptions' with version '0.2.2' for the module 'AzureStack'.
VERBOSE: Module 'Azs.Subscriptions' was installed successfully to path 'C:\Program Files\WindowsPowerShell\Modules\Azs.Subscriptions\0.2.2'.
VERBOSE: Completed downloading 'https://www.powershellgallery.com/api/v2/package/Azs.Update.Admin/0.2.3'.
VERBOSE: Completed downloading 'Azs.Update.Admin'.
VERBOSE: Hash for package 'Azs.Update.Admin' does not match hash provided from the server.
VERBOSE: InstallPackageLocal' - name='Azs.Update.Admin', version='0.2.3',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566'
VERBOSE: InstallPackage' - name='AzureStack', version='1.7.2',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566'
VERBOSE: DownloadPackage' - name='AzureStack', version='1.7.2',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566\AzureStack\AzureStack.nupkg', uri='https://www.powershellgallery.com/api/v2/package/AzureStack/1.7.2'
VERBOSE: Catalog file 'Azs.Subscriptions.Admin.cat' is not found in the contents of the module 'Azs.Subscriptions.Admin' being installed.
VERBOSE: Downloading 'https://www.powershellgallery.com/api/v2/package/AzureStack/1.7.2'.
VERBOSE: Completed downloading 'https://www.powershellgallery.com/api/v2/package/AzureStack/1.7.2'.
VERBOSE: Completed downloading 'AzureStack'.
VERBOSE: Hash for package 'AzureStack' does not match hash provided from the server.
VERBOSE: InstallPackageLocal' - name='AzureStack', version='1.7.2',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\467311566'
VERBOSE: Installing the dependency module 'Azs.Subscriptions.Admin' with version '0.3.3' for the module 'AzureStack'.
VERBOSE: Module 'Azs.Subscriptions.Admin' was installed successfully to path 'C:\Program Files\WindowsPowerShell\Modules\Azs.Subscriptions.Admin\0.3.3'.
VERBOSE: Catalog file 'Azs.Update.Admin.cat' is not found in the contents of the module 'Azs.Update.Admin' being installed.
VERBOSE: Installing the dependency module 'Azs.Update.Admin' with version '0.2.3' for the module 'AzureStack'.
VERBOSE: Module 'Azs.Update.Admin' was installed successfully to path 'C:\Program Files\WindowsPowerShell\Modules\Azs.Update.Admin\0.2.3'.
VERBOSE: Catalog file 'AzureStack.cat' is not found in the contents of the module 'AzureStack' being installed.
VERBOSE: Module 'AzureStack' was installed successfully to path 'C:\Program Files\WindowsPowerShell\Modules\AzureStack\1.7.2'.
PS C:\> Install-Module -Name Azure.Storage -RequiredVersion 4.5.0 -AllowClobber -Force -Verbose
VERBOSE: Using the provider 'PowerShellGet' for searching packages.
VERBOSE: The -Repository parameter was not specified.  PowerShellGet will use all of the registered repositories.
VERBOSE: Getting the provider object for the PackageManagement Provider 'NuGet'.
VERBOSE: The specified Location is 'https://www.powershellgallery.com/api/v2' and PackageManagementProvider is 'NuGet'.
VERBOSE: Searching repository 'https://www.powershellgallery.com/api/v2/FindPackagesById()?id='Azure.Storage'' for ''.
VERBOSE: Total package yield:'1' for the specified package 'Azure.Storage'.
VERBOSE: Performing the operation "Install-Module" on target "Version '4.5.0' of module 'Azure.Storage'".
VERBOSE: The installation scope is specified to be 'AllUsers'.
VERBOSE: The specified module will be installed in 'C:\Program Files\WindowsPowerShell\Modules'.
VERBOSE: The specified Location is 'NuGet' and PackageManagementProvider is 'NuGet'.
VERBOSE: Downloading module 'Azure.Storage' with version '4.5.0' from the repository 'https://www.powershellgallery.com/api/v2'.
VERBOSE: Searching repository 'https://www.powershellgallery.com/api/v2/FindPackagesById()?id='Azure.Storage'' for ''.
VERBOSE: Searching repository 'https://www.powershellgallery.com/api/v2/FindPackagesById()?id='AzureRM.Profile'' for ''.
VERBOSE: InstallPackage' - name='AzureRM.profile', version='5.8.3',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\141826803'
VERBOSE: DownloadPackage' - name='AzureRM.profile', version='5.8.3',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\141826803\AzureRM.profile\AzureRM.profile.nupkg', uri='https://www.powershellgallery.com/api/v2/package/AzureRM.profile/5.8.3'
VERBOSE: Downloading 'https://www.powershellgallery.com/api/v2/package/AzureRM.profile/5.8.3'.
VERBOSE: Completed downloading 'https://www.powershellgallery.com/api/v2/package/AzureRM.profile/5.8.3'.
VERBOSE: Completed downloading 'AzureRM.profile'.
VERBOSE: Hash for package 'AzureRM.profile' does not match hash provided from the server.
VERBOSE: InstallPackageLocal' - name='AzureRM.profile', version='5.8.3',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\141826803'
VERBOSE: InstallPackage' - name='Azure.Storage', version='4.5.0',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\141826803'
VERBOSE: DownloadPackage' - name='Azure.Storage', version='4.5.0',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\141826803\Azure.Storage\Azure.Storage.nupkg', uri='https://www.powershellgallery.com/api/v2/package/Azure.Storage/4.5.0'
VERBOSE: Downloading 'https://www.powershellgallery.com/api/v2/package/Azure.Storage/4.5.0'.
VERBOSE: Completed downloading 'https://www.powershellgallery.com/api/v2/package/Azure.Storage/4.5.0'.
VERBOSE: Completed downloading 'Azure.Storage'.
VERBOSE: Hash for package 'Azure.Storage' does not match hash provided from the server.
VERBOSE: InstallPackageLocal' - name='Azure.Storage', version='4.5.0',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\141826803'
VERBOSE: Catalog file 'AzureRM.profile.cat' is not found in the contents of the module 'AzureRM.profile' being installed.
VERBOSE: For publisher validation, current module 'AzureRM.profile' with version '5.8.3' with publisher name ''. Is this module signed by Microsoft: 'False'.
VERBOSE: For publisher validation, using the previously-installed module 'AzureRM.profile' with version '5.8.3' under 'C:\Program Files\WindowsPowerShell\Modules\AzureRM.profile\5.8.3' with publisher name ''. Is this module signed by Microsoft: 'False'.
VERBOSE: Installing the dependency module 'AzureRM.profile' with version '5.8.3' for the module 'Azure.Storage'.
WARNING: The version '5.8.3' of module 'AzureRM.profile' is currently in use. Retry the operation after closing the applications.
VERBOSE: Module 'AzureRM.profile' is in currently in use.
VERBOSE: Catalog file 'Azure.Storage.cat' is not found in the contents of the module 'Azure.Storage' being installed.
VERBOSE: For publisher validation, current module 'Azure.Storage' with version '4.5.0' with publisher name ''. Is this module signed by Microsoft: 'False'.
VERBOSE: For publisher validation, using the previously-installed module 'Azure.Storage' with version '4.5.0' under 'C:\Program Files\WindowsPowerShell\Modules\Azure.Storage\4.5.0' with publisher name ''. Is this module signed by Microsoft: 'False'.
WARNING: The version '4.5.0' of module 'Azure.Storage' is currently in use. Retry the operation after closing the applications.
VERBOSE: Module 'Azure.Storage' is in currently in use.
PS C:\> Install-Module -Name AzureRM.Storage -RequiredVersion 5.0.4 -AllowClobber -Force -Verbose
VERBOSE: Using the provider 'PowerShellGet' for searching packages.
VERBOSE: The -Repository parameter was not specified.  PowerShellGet will use all of the registered repositories.
VERBOSE: Getting the provider object for the PackageManagement Provider 'NuGet'.
VERBOSE: The specified Location is 'https://www.powershellgallery.com/api/v2' and PackageManagementProvider is 'NuGet'.
VERBOSE: Searching repository 'https://www.powershellgallery.com/api/v2/FindPackagesById()?id='AzureRM.Storage'' for ''.
VERBOSE: Total package yield:'1' for the specified package 'AzureRM.Storage'.
VERBOSE: Performing the operation "Install-Module" on target "Version '5.0.4' of module 'AzureRM.Storage'".
VERBOSE: The installation scope is specified to be 'AllUsers'.
VERBOSE: The specified module will be installed in 'C:\Program Files\WindowsPowerShell\Modules'.
VERBOSE: The specified Location is 'NuGet' and PackageManagementProvider is 'NuGet'.
VERBOSE: Downloading module 'AzureRM.Storage' with version '5.0.4' from the repository 'https://www.powershellgallery.com/api/v2'.
VERBOSE: Searching repository 'https://www.powershellgallery.com/api/v2/FindPackagesById()?id='AzureRM.Storage'' for ''.
VERBOSE: Searching repository 'https://www.powershellgallery.com/api/v2/FindPackagesById()?id='AzureRM.Profile'' for ''.
VERBOSE: Searching repository 'https://www.powershellgallery.com/api/v2/FindPackagesById()?id='Azure.Storage'' for ''.
VERBOSE: Searching repository 'https://www.powershellgallery.com/api/v2/FindPackagesById()?id='AzureRM.Profile'' for ''.
VERBOSE: InstallPackage' - name='AzureRM.profile', version='5.8.3',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\1456831287'
VERBOSE: DownloadPackage' - name='AzureRM.profile', version='5.8.3',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\1456831287\AzureRM.profile\AzureRM.profile.nupkg', uri='https://www.powershellgallery.com/api/v2/package/AzureRM.profile/5.8.3'
VERBOSE: Downloading 'https://www.powershellgallery.com/api/v2/package/AzureRM.profile/5.8.3'.
VERBOSE: Completed downloading 'https://www.powershellgallery.com/api/v2/package/AzureRM.profile/5.8.3'.
VERBOSE: Completed downloading 'AzureRM.profile'.
VERBOSE: Hash for package 'AzureRM.profile' does not match hash provided from the server.
VERBOSE: InstallPackageLocal' - name='AzureRM.profile', version='5.8.3',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\1456831287'
VERBOSE: InstallPackage' - name='Azure.Storage', version='4.6.1',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\1456831287'
VERBOSE: DownloadPackage' - name='Azure.Storage', version='4.6.1',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\1456831287\Azure.Storage\Azure.Storage.nupkg', uri='https://www.powershellgallery.com/api/v2/package/Azure.Storage/4.6.1'
VERBOSE: Downloading 'https://www.powershellgallery.com/api/v2/package/Azure.Storage/4.6.1'.
VERBOSE: Completed downloading 'https://www.powershellgallery.com/api/v2/package/Azure.Storage/4.6.1'.
VERBOSE: Completed downloading 'Azure.Storage'.
VERBOSE: Hash for package 'Azure.Storage' does not match hash provided from the server.
VERBOSE: InstallPackageLocal' - name='Azure.Storage', version='4.6.1',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\1456831287'
VERBOSE: InstallPackage' - name='AzureRM.Storage', version='5.0.4',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\1456831287'
VERBOSE: DownloadPackage' - name='AzureRM.Storage', version='5.0.4',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\1456831287\AzureRM.Storage\AzureRM.Storage.nupkg', uri='https://www.powershellgallery.com/api/v2/package/AzureRM.Storage/5.0.4'
VERBOSE: Downloading 'https://www.powershellgallery.com/api/v2/package/AzureRM.Storage/5.0.4'.
VERBOSE: Catalog file 'AzureRM.profile.cat' is not found in the contents of the module 'AzureRM.profile' being installed.
VERBOSE: For publisher validation, current module 'AzureRM.profile' with version '5.8.3' with publisher name ''. Is this module signed by Microsoft: 'False'.
VERBOSE: For publisher validation, using the previously-installed module 'AzureRM.profile' with version '5.8.3' under 'C:\Program Files\WindowsPowerShell\Modules\AzureRM.profile\5.8.3' with publisher name ''. Is this module signed by Microsoft: 'False'.
VERBOSE: Installing the dependency module 'AzureRM.profile' with version '5.8.3' for the module 'AzureRM.Storage'.
WARNING: The version '5.8.3' of module 'AzureRM.profile' is currently in use. Retry the operation after closing the applications.
VERBOSE: Module 'AzureRM.profile' is in currently in use.
VERBOSE: Completed downloading 'https://www.powershellgallery.com/api/v2/package/AzureRM.Storage/5.0.4'.
VERBOSE: Completed downloading 'AzureRM.Storage'.
VERBOSE: Hash for package 'AzureRM.Storage' does not match hash provided from the server.
VERBOSE: InstallPackageLocal' - name='AzureRM.Storage', version='5.0.4',destination='C:\Users\ContainerAdministrator\AppData\Local\Temp\1456831287'
VERBOSE: Catalog file 'Azure.Storage.cat' is not found in the contents of the module 'Azure.Storage' being installed.
VERBOSE: For publisher validation, current module 'Azure.Storage' with version '4.6.1' with publisher name ''. Is this module signed by Microsoft: 'False'.
VERBOSE: For publisher validation, using the previously-installed module 'Azure.Storage' with version '4.5.0' under 'C:\Program Files\WindowsPowerShell\Modules\Azure.Storage\4.5.0' with publisher name ''. Is this module signed by Microsoft: 'False'.
VERBOSE: Installing the dependency module 'Azure.Storage' with version '4.6.1' for the module 'AzureRM.Storage'.
VERBOSE: Module 'Azure.Storage' was installed successfully to path 'C:\Program Files\WindowsPowerShell\Modules\Azure.Storage\4.6.1'.
VERBOSE: Catalog file 'AzureRM.Storage.cat' is not found in the contents of the module 'AzureRM.Storage' being installed.
VERBOSE: For publisher validation, current module 'AzureRM.Storage' with version '5.0.4' with publisher name ''. Is this module signed by Microsoft: 'False'.
VERBOSE: For publisher validation, using the previously-installed module 'AzureRM.Storage' with version '5.0.4' under 'C:\Program Files\WindowsPowerShell\Modules\AzureRM.Storage\5.0.4' with publisher name ''. Is this module signed by Microsoft: 'False'.
WARNING: The version '5.0.4' of module 'AzureRM.Storage' is currently in use. Retry the operation after closing the applications.
VERBOSE: Module 'AzureRM.Storage' is in currently in use.
PS C:\> Uninstall-Module Azure.Storage -RequiredVersion 4.6.1 -Force -Verbose
VERBOSE: Successfully uninstalled the module 'Azure.Storage' from module base 'C:\Program Files\WindowsPowerShell\Modules\Azure.Storage\4.6.1'.
PS C:\> Import-Module -Name AzureStack -Verbose
VERBOSE: Loading module from path 'C:\Program Files\WindowsPowerShell\Modules\AzureStack\1.7.2\AzureStack.psd1'.
VERBOSE: Populating RepositorySourceLocation property for module AzureStack.
VERBOSE: Loading module from path 'C:\Program Files\WindowsPowerShell\Modules\AzureStack\1.7.2\AzureStack.psm1'.
WARNING: Preview version of the module Azs.Azurebridge.Admin loaded. Future release of this module may have breaking changes.
WARNING: Preview version of the module Azs.Backup.Admin loaded. Future release of this module may have breaking changes.
WARNING: Preview version of the module Azs.Commerce.Admin loaded. Future release of this module may have breaking changes.
WARNING: Preview version of the module Azs.Compute.Admin loaded. Future release of this module may have breaking changes.
WARNING: Preview version of the module Azs.Fabric.Admin loaded. Future release of this module may have breaking changes.
WARNING: Preview version of the module Azs.Gallery.Admin loaded. Future release of this module may have breaking changes.
WARNING: Preview version of the module Azs.Infrastructureinsights.Admin loaded. Future release of this module may have breaking changes.
WARNING: Preview version of the module Azs.Keyvault.Admin loaded. Future release of this module may have breaking changes.
WARNING: Preview version of the module Azs.Network.Admin loaded. Future release of this module may have breaking changes.
WARNING: Preview version of the module Azs.Storage.Admin loaded. Future release of this module may have breaking changes.
WARNING: Preview version of the module Azs.Subscriptions loaded. Future release of this module may have breaking changes.
WARNING: Preview version of the module Azs.Subscriptions.Admin loaded. Future release of this module may have breaking changes.
WARNING: Preview version of the module Azs.Update.Admin loaded. Future release of this module may have breaking changes.
VERBOSE: Exporting function 'Test-DotNet'.
PS C:\>
```

In an easier to read format :-)
```powershell
Windows PowerShell
Copyright (C) 2016 Microsoft Corporation. All rights reserved.

PS C:\>
PS C:\> Remove-Module -Name PSReadline
PS C:\> Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Confirm:$false -Force

Name                           Version          Source           Summary
----                           -------          ------           -------
nuget                          2.8.5.208        https://onege... NuGet provider for the OneGet meta-package manager


PS C:\> Set-PSRepository -Name "PSGallery" -InstallationPolicy Trusted
PS C:\> Install-Module -Name AzureRM.BootStrapper
PS C:\> Use-AzureRmProfile -Profile 2019-03-01-hybrid -Force
Loading Profile 2019-03-01-hybrid
PS C:\> Install-Module -Name AzureStack -RequiredVersion 1.7.2
PS C:\> Install-Module -Name Azure.Storage -RequiredVersion 4.5.0 -Force -AllowClobber
WARNING: The version '5.8.3' of module 'AzureRM.profile' is currently in use. Retry the operation after closing the applications.
WARNING: The version '4.5.0' of module 'Azure.Storage' is currently in use. Retry the operation after closing the applications.
PS C:\> Install-Module -Name AzureRM.Storage -RequiredVersion 5.0.4 -Force -AllowClobber
WARNING: The version '5.8.3' of module 'AzureRM.profile' is currently in use. Retry the operation after closing the applications.
WARNING: The version '5.0.4' of module 'AzureRM.Storage' is currently in use. Retry the operation after closing the applications.
PS C:\> Uninstall-Module -Name Azure.Storage -RequiredVersion 4.6.1 -Force
PS C:\> Import-Module -Name AzureStack -Verbose
VERBOSE: Loading module from path 'C:\Program Files\WindowsPowerShell\Modules\AzureStack\1.7.2\AzureStack.psd1'.
VERBOSE: Populating RepositorySourceLocation property for module AzureStack.
VERBOSE: Loading module from path 'C:\Program Files\WindowsPowerShell\Modules\AzureStack\1.7.2\AzureStack.psm1'.
WARNING: Preview version of the module Azs.Azurebridge.Admin loaded. Future release of this module may have breaking changes.
WARNING: Preview version of the module Azs.Backup.Admin loaded. Future release of this module may have breaking changes.
WARNING: Preview version of the module Azs.Commerce.Admin loaded. Future release of this module may have breaking changes.
WARNING: Preview version of the module Azs.Compute.Admin loaded. Future release of this module may have breaking changes.
WARNING: Preview version of the module Azs.Fabric.Admin loaded. Future release of this module may have breaking changes.
WARNING: Preview version of the module Azs.Gallery.Admin loaded. Future release of this module may have breaking changes.
WARNING: Preview version of the module Azs.Infrastructureinsights.Admin loaded. Future release of this module may have breaking changes.
WARNING: Preview version of the module Azs.Keyvault.Admin loaded. Future release of this module may have breaking changes.
WARNING: Preview version of the module Azs.Network.Admin loaded. Future release of this module may have breaking changes.
WARNING: Preview version of the module Azs.Storage.Admin loaded. Future release of this module may have breaking changes.
WARNING: Preview version of the module Azs.Subscriptions loaded. Future release of this module may have breaking changes.
WARNING: Preview version of the module Azs.Subscriptions.Admin loaded. Future release of this module may have breaking changes.
WARNING: Preview version of the module Azs.Update.Admin loaded. Future release of this module may have breaking changes.
VERBOSE: Exporting function 'Test-DotNet'.
PS C:\>
```


```powershell
PS C:\> Get-Module

ModuleType Version    Name                                ExportedCommands
---------- -------    ----                                ----------------
Script     0.2.2      Azs.AzureBridge.Admin               {Get-AzsAzureBridgeActivation, Get-AzsAzureBridgeDownloadedProduct, Get-AzsAzureBridgeProduct, Invoke-AzsAzureBridgeProductDownload...}
Script     0.3.1      Azs.Backup.Admin                    {Get-AzsBackup, Get-AzsBackupConfiguration, New-AzsEncryptionKeyBase64, Restore-AzsBackup...}
Script     0.2.2      Azs.Commerce.Admin                  Get-AzsSubscriberUsage
Script     0.2.3      Azs.Compute.Admin                   {Add-AzsPlatformImage, Add-AzsVMExtension, Get-AzsComputeQuota, Get-AzsDisk...}
Script     0.4.1      Azs.Fabric.Admin                    {Add-AzsScaleUnitNode, Disable-AzsScaleUnitNode, Enable-AzsScaleUnitNode, Get-AzsDrive...}
Script     0.2.2      Azs.Gallery.Admin                   {Add-AzsGalleryItem, Get-AzsGalleryItem, Remove-AzsGalleryItem}
Script     0.3.2      Azs.InfrastructureInsights.Admin    {Close-AzsAlert, Get-AzsAlert, Get-AzsRegionHealth, Get-AzsRegistrationHealth...}
Script     0.2.2      Azs.KeyVault.Admin                  Get-AzsKeyVaultQuota
Script     0.2.2      Azs.Network.Admin                   {Get-AzsLoadBalancer, Get-AzsNetworkAdminOverview, Get-AzsNetworkQuota, Get-AzsPublicIPAddress...}
Script     0.2.3      Azs.Storage.Admin                   {Get-AzsBlobService, Get-AzsBlobServiceMetric, Get-AzsBlobServiceMetricDefinition, Get-AzsQueueService...}
Script     0.2.2      Azs.Subscriptions                   {Get-AzsDelegatedProviderOffer, Get-AzsOffer, Get-AzsSubscription, New-AzsSubscription...}
Script     0.3.3      Azs.Subscriptions.Admin             {Add-AzsPlanToOffer, Get-AzsDelegatedProvider, Get-AzsDelegatedProviderManagedOffer, Get-AzsDirectoryTenant...}
Script     0.2.3      Azs.Update.Admin                    {Get-AzsUpdate, Get-AzsUpdateLocation, Get-AzsUpdateRun, Install-AzsUpdate...}
Script     4.5.0      Azure.Storage                       {Disable-AzureStorageDeleteRetentionPolicy, Enable-AzureStorageDeleteRetentionPolicy, Get-AzureStorageBlob, Get-AzureStorageBlobContent...}
Script     2.5.0      AzureRM
Script     0.5.0      AzureRM.BootStrapper                {Get-AzureRmModule, Get-AzureRmProfile, Get-ModuleVersion, Install-AzureRmProfile...}
Script     4.6.1      AzureRM.Compute                     {Add-AzureRmContainerServiceAgentPoolProfile, Add-AzureRmImageDataDisk, Add-AzureRmVhd, Add-AzureRmVMAdditionalUnattendContent...}
Script     3.5.1      AzureRM.Dns                         {Add-AzureRmDnsRecordConfig, Get-AzureRmDnsRecordSet, Get-AzureRmDnsZone, New-AzureRmDnsRecordConfig...}
Script     5.1.5      AzureRM.Insights                    {Add-AzureRmAutoscaleSetting, Add-AzureRmLogProfile, Add-AzureRmMetricAlertRule, Add-AzureRmWebtestAlertRule...}
Script     4.2.0      AzureRM.KeyVault                    {Add-AzureKeyVaultCertificate, Add-AzureKeyVaultCertificateContact, Add-AzureKeyVaultKey, Add-AzureKeyVaultManagedStorageAccount...}
Script     5.0.1      AzureRM.Network                     {Add-AzureRmApplicationGatewayAuthenticationCertificate, Add-AzureRmApplicationGatewayBackendAddressPool, Add-AzureRmApplicationGatewayBackendHttpSettings, Add-AzureRmApplicationGatewayFrontendIPConfig...}
Script     5.8.3      AzureRM.Profile                     {Add-AzureRmEnvironment, Clear-AzureRmContext, Clear-AzureRmDefault, Connect-AzureRmAccount...}
Script     6.4.3      AzureRM.Resources                   {Add-AzureRmADGroupMember, Export-AzureRmResourceGroup, Get-AzureRmADAppCredential, Get-AzureRmADApplication...}
Script     5.0.4      AzureRM.Storage                     {Add-AzureRmStorageAccountNetworkRule, Get-AzureRmStorageAccount, Get-AzureRmStorageAccountKey, Get-AzureRmStorageAccountNameAvailability...}
Script     4.0.2      AzureRM.Tags                        {Get-AzureRmTag, New-AzureRmTag, Remove-AzureRmTag}
Script     4.0.3      AzureRM.UsageAggregates             Get-UsageAggregates
Script     5.0.1      AzureRM.Websites                    {Edit-AzureRmWebAppBackupConfiguration, Get-AzureRmAppServicePlan, Get-AzureRmAppServicePlanMetrics, Get-AzureRmWebApp...}
Script     1.7.2      AzureStack
Manifest   3.1.0.0    Microsoft.PowerShell.Management     {Add-Computer, Add-Content, Checkpoint-Computer, Clear-Content...}
Manifest   3.1.0.0    Microsoft.PowerShell.Utility        {Add-Member, Add-Type, Clear-Variable, Compare-Object...}
Binary     1.0.0.1    PackageManagement                   {Find-Package, Find-PackageProvider, Get-Package, Get-PackageProvider...}
Script     1.0.0.1    PowerShellGet                       {Find-Command, Find-DscResource, Find-Module, Find-RoleCapability...}
```