### PR TITLE
Add known issue with ConvertTo-AzureRmVMManagedDisk 

### DIFF
--- a/azure-stack/operator/azure-stack-release-notes-known-issues-1904.md
+++ b/azure-stack/operator/azure-stack-release-notes-known-issues-1904.md
@@ -182,7 +182,7 @@ Please disable Compute Host Agent feature flag and collect logs for further diag
 
 - Applicable: This issue applies to all supported releases.
 - Cause: [ConvertTo-AzureRmVMManagedDisk](/powershell/module/azurerm.compute/convertto-azurermvmmanageddisk) is not supported in Azure Stack and will result in creating a disk with $null ID. This will in turn prevent you from doing operations on said VM like: start and stop. The disk will not show in the UI, nor will it show via API. VM at that point cannot be fixed and has to be deleted.
-- Remediation: To convert your disks correctly follow [Convert to managed disks guide](/user/azure-stack-managed-disk-considerations.md#convert-to-managed-disks)
+- Remediation: To convert your disks correctly follow the [convert to managed disks guide](/user/azure-stack-managed-disk-considerations.md#convert-to-managed-disks).
 
 ## App Service
 

--- a/azure-stack/operator/azure-stack-release-notes-known-issues-1904.md
+++ b/azure-stack/operator/azure-stack-release-notes-known-issues-1904.md
@@ -181,7 +181,7 @@ Please disable Compute Host Agent feature flag and collect logs for further diag
 ### Converting currently provisioned VM from unmanaged to managed disks
 
 - Applicable: This issue applies to all supported releases.
-- Cause: [ConvertTo-AzureRmVMManagedDisk](/powershell/module/azurerm.compute/convertto-azurermvmmanageddisk) is not supported in Azure Stack and will result in creating a disk with $null ID. This will in turn prevent you from doing operations on said VM like: start and stop. The disk will not show in the UI, nor will it show via API. VM at that point cannot be fixed and has to be deleted.
+- Cause: [ConvertTo-AzureRmVMManagedDisk](/powershell/module/azurerm.compute/convertto-azurermvmmanageddisk) is not supported in Azure Stack and will result in creating a disk with $null ID. This will in turn prevent you from performing operations on the VM such as start and stop. The disk will not show in the UI, nor will it show via API. The VM at that point cannot be repaired and has to be deleted.
 - Remediation: To convert your disks correctly follow the [convert to managed disks guide](/user/azure-stack-managed-disk-considerations.md#convert-to-managed-disks).
 
 ## App Service

--- a/azure-stack/operator/azure-stack-release-notes-known-issues-1904.md
+++ b/azure-stack/operator/azure-stack-release-notes-known-issues-1904.md
@@ -66,15 +66,15 @@ This article lists known issues in the 1904 release of Azure Stack. The list is 
 ### Marketplace management
 
 - Applicable: This issue applies to 1904.
-- Cause: When you filter results in the **Add from Azure** blade in the Marketplace management tab in the administrator portal, you may see incorrect filtered results. 
-- Remediation: Sort results by the Name column and the results will be corrected. 
+- Cause: When you filter results in the **Add from Azure** blade in the Marketplace management tab in the administrator portal, you may see incorrect filtered results.
+- Remediation: Sort results by the Name column and the results will be corrected.
 - Occurrence: Intermittent
 
 ### Marketplace management
 
 - Applicable: This issue applies to 1904.
 - Cause: When you filter results in Marketplace management in the administrator portal, you will see duplicated publisher names under the publisher drop-down. 
-- Remediation: Select all the duplicates to have the correct list of all the Marketplace products that are available under that publisher. 
+- Remediation: Select all the duplicates to have the correct list of all the Marketplace products that are available under that publisher.
 - Occurrence: Intermittent
 
 ### Upload blob
@@ -175,6 +175,14 @@ Please disable Compute Host Agent feature flag and collect logs for further diag
   - This alert can be ignored. The agent not responding does not have any impact on operator and user operations or user applications. The alert will reappear after 24 hours if it is closed manually.
   - Microsoft support can remediate the issue by changing the startup setting for the service. This requires opening a support ticket. If the node is restarted again, a new alert appears.
 - Occurrence: Common
+
+## Storage
+
+### Converting currently provisioned VM from unmanaged to managed disks
+
+- Applicable: This issue applies to all supported releases.
+- Cause: [ConvertTo-AzureRmVMManagedDisk](/powershell/module/azurerm.compute/convertto-azurermvmmanageddisk) is not supported in Azure Stack and will result in creating a disk with $null ID. This will in turn prevent you from doing operations on said VM like: start and stop. The disk will not show in the UI, nor will it show via API. VM at that point cannot be fixed and has to be deleted.
+- Remediation: To convert your disks correctly follow [Convert to managed disks guide](/user/azure-stack-managed-disk-considerations.md#convert-to-managed-disks)
 
 ## App Service
 


### PR DESCRIPTION
As discussed with MSFT support ConvertTo-AzureRmVMManagedDisk is not support on Azure Stack but it will result in breaking your VM.

Due to this sad fact, I think it is important we warn our customers about it as this came from a customer of mine who wanted to do said conversion and we went for the aforementioned command first.

Internal Bug from MSFT Support (Ref: 1540556) to help you verify it.

I hope I put the reference links correctly to the user documentation but I might have done it wrong... so would appreciate some help here :)