### PR TITLE
Deleted ", SerialNumber" at line 155

### DIFF
--- a/azure-stack/operator/azure-stack-storage-infrastructure-overview.md
+++ b/azure-stack/operator/azure-stack-storage-infrastructure-overview.md
@@ -152,8 +152,6 @@ $scaleunit_name = (Get-AzsScaleUnit)[0].name
 
 $subsystem_name = (Get-AzsStorageSubSystem -ScaleUnit $scaleunit_name)[0].name
 
-, SerialNumber
-
 Get-AzsDrive -ScaleUnit $scaleunit_name -StorageSubSystem $subsystem_name | Select-Object StorageNode, PhysicalLocation, HealthStatus, OperationalStatus, Description, Action, Usage, CanPool, CannotPoolReason, SerialNumber, Model, MediaType, CapacityGB
 ```
 


### PR DESCRIPTION
", SerialNumber" is not needed to confirm Drive states. I think this is typo, because "SerialNumber" object is selected for Get-AzsDrive.