### PR TITLE
Clarifying 1906 runtime does not depend on # nodes

### DIFF
--- a/azure-stack/operator/azure-stack-release-notes-1906.md
+++ b/azure-stack/operator/azure-stack-release-notes-1906.md
@@ -34,7 +34,7 @@ The Azure Stack 1906 update build number is **1.1906.0.30**.
 
 ### Update type
 
-The Azure Stack 1906 update build type is **Express**. For more information about update build types, see the [Manage updates in Azure Stack](azure-stack-updates.md) article. The expected time it takes for the 1906 update to complete is approximately 10 hours. Exact update runtimes will typically depend on the capacity used on your system by tenant workloads, your system network connectivity (if connected to the internet), and your system hardware configuration. Runtimes lasting longer than the expected value are not uncommon and do not require action by Azure Stack operators unless the update fails. This runtime approximation is specific to the 1906 update and should not be compared to other Azure Stack updates.
+The Azure Stack 1906 update build type is **Express**. For more information about update build types, see the [Manage updates in Azure Stack](azure-stack-updates.md) article. The expected time it takes for the 1906 update to complete is approximately 10 hours, regardless of the number of physical nodes in your Azure Stack environment. Exact update runtimes will typically depend on the capacity used on your system by tenant workloads, your system network connectivity (if connected to the internet), and your system hardware specifications. Runtimes lasting longer than the expected value are not uncommon and do not require action by Azure Stack operators unless the update fails. This runtime approximation is specific to the 1906 update and should not be compared to other Azure Stack updates.
 
 ## What's in this update
 


### PR DESCRIPTION
Clarifying 1906 runtime does not depend on # of nodes