### PR TITLE
Replace en-dash with two hyphens in K8S commands.

### DIFF
--- a/azure-stack/user/azure-stack-kubernetes-aks-engine-deploy-cluster.md
+++ b/azure-stack/user/azure-stack-kubernetes-aks-engine-deploy-cluster.md
@@ -166,7 +166,7 @@ Verify your cluster by deploying mysql with Helm to check your cluster.
 4.  Run the following commands:
 
     ```bash
-    sudo snap install helm –classic
+    sudo snap install helm --classic
     kubectl -n kube-system create serviceaccount tiller
     kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
     helm init --service-account=tiller

--- a/azure-stack/user/azure-stack-kubernetes-aks-engine-scale.md
+++ b/azure-stack/user/azure-stack-kubernetes-aks-engine-scale.md
@@ -46,7 +46,7 @@ The following parameters are used by the scale command to find your cluster defi
 | -master-FQDN |  | Master FQDN. Needed when scaling down. |
 | identity-system | adfs | Optional. Specify your identity management solution if you are using Active Directory Federated Services (AD FS). |
 
-You must specify the **–azure-env** parameter when scaling a cluster in Azure Stack. For more information about parameters and their values used in the **scale** command for the AKS Engine, see [Scale - parameters](https://github.com/Azure/aks-engine/blob/master/docs/topics/scale.md#parameters).
+You must specify the **--azure-env** parameter when scaling a cluster in Azure Stack. For more information about parameters and their values used in the **scale** command for the AKS Engine, see [Scale - parameters](https://github.com/Azure/aks-engine/blob/master/docs/topics/scale.md#parameters).
 
 ### Command to scale your cluster
 


### PR DESCRIPTION
Hi,

I've replaced two instances of the en-dash with two hyphens, to help aid in copy & pasting the commands. :-)