### PR TITLE
Fix Diagnostics data URL

### DIFF
--- a/azure-stack/operator/azure-stack-telemetry.md
+++ b/azure-stack/operator/azure-stack-telemetry.md
@@ -32,7 +32,7 @@ For an Azure Stack operator, telemetry can provide valuable insights into enterp
 Azure Stack telemetry is based on the Windows Server 2016 Connected User Experience and Telemetry component, which uses the [Event Tracing for Windows (ETW)](https://msdn.microsoft.com/library/dn904632(v=vs.85).aspx) TraceLogging technology to gather and store events and data. Azure Stack components use the same technology to publish events and data gathered by using public operating system event logging and tracing APIs. Examples of these Azure Stack components include these providers: Network Resource, Storage Resource, Monitoring Resource, and Update Resource. The Connected User Experience and Telemetry component encrypts data using SSL and uses certificate pinning to transmit data over HTTPS to the Microsoft Data Management service.
 
 > [!IMPORTANT]
-> To enable telemetry data flow, port 443 (HTTPS) must be open in your network. The Connected User Experience and Telemetry component connects to the Microsoft Data Management service at https://v10.vortex-win.data.microsoft.com. The Connected User Experience and Telemetry component also connects to https://settings-win.data.microsoft.com to download configuration information.
+> To enable telemetry data flow, port 443 (HTTPS) must be open in your network. The Connected User Experience and Telemetry component connects to the Microsoft Data Management service at https://v10.events.data.microsoft.com. The Connected User Experience and Telemetry component also connects to https://settings-win.data.microsoft.com to download configuration information. Other diagnostic data services connect https://watson.telemetry.microsoft.com for error reporting.
 
 ## Privacy considerations
 


### PR DESCRIPTION
Telemetry URL "https://v10.vortex-win.data.microsoft.com" is for early 1803 version. And please add "watson.telemetry.microsoft.com" because Azure Stack Hub connects to the URL for error reporting.