### PR TITLE
changed "EventHub" to "EventHubs"

### DIFF
--- a/azure-stack/operator/azure-stack-validate-pki-certs.md
+++ b/azure-stack/operator/azure-stack-validate-pki-certs.md
@@ -154,7 +154,7 @@ Use these steps to prepare and to validate the Azure Stack PKI certificates for 
     Invoke-AzsCertificateValidation -CertificateType DBAdapter -CertificatePath C:\Certificates\DBAdapter -pfxPassword $pfxPassword -RegionName east -FQDN azurestack.contoso.com
 
     # EventHub
-    Invoke-AzsCertificateValidation -CertificateType EventHub -CertificatePath C:\Certificates\EventHub -pfxPassword $pfxPassword -RegionName east -FQDN azurestack.contoso.com
+    Invoke-AzsCertificateValidation -CertificateType EventHubs -CertificatePath C:\Certificates\EventHub -pfxPassword $pfxPassword -RegionName east -FQDN azurestack.contoso.com
 
     # IoTHub
     Invoke-AzsCertificateValidation -CertificateType IoTHub -CertificatePath C:\Certificates\IoTHub -pfxPassword $pfxPassword -RegionName east -FQDN azurestack.contoso.com


### PR DESCRIPTION
readiness checker looks for "EventHubs" with the "s" at the end.