### PR TITLE
Prerequisites for .NET Framework

### DIFF
--- a/azure-stack/operator/azure-stack-download-azure-marketplace-item.md
+++ b/azure-stack/operator/azure-stack-download-azure-marketplace-item.md
@@ -91,6 +91,8 @@ There are two parts to this scenario:
   ```
   Install-Module -Name Azs.Syndication.Admin
   ```
+  
+- .NET Framework 4.7 or later versions
 
 Once you have registered your Azure Stack, you can disregard the following message that appears on the Marketplace management blade, as this is not relevant for the disconnected use case:
 


### PR DESCRIPTION
If I executed Export-AzsMarketplaceItem without .NET Framework v4.7.2, the command didn’t work with message "need .NET Framework v4.7.2".
The command works fine after I installed .NET Framework 4.8.