### PR TITLE
Update service-plan-offer-subscription-overview.md

### DIFF
--- a/azure-stack/operator/service-plan-offer-subscription-overview.md
+++ b/azure-stack/operator/service-plan-offer-subscription-overview.md
@@ -99,9 +99,9 @@ Subscriptions let users access your offers. If you're an Azure Stack Hub operato
 
 Users create new subscriptions and get access to existing subscriptions by signing in to Azure Stack Hub. Each subscription represents an association with a single offer. The offer (and its plans and quotas) assigned to one subscription can't be shared with other subscriptions. Each resource that a user creates is associated with one subscription.
 
-As an Azure Stack Hub operator, you are able to see information about tenant subscriptions, however are unable to access the contents of those subscriptions unless explicitly added through RBAC by a tenant administrator of that subscription. This enables tenants to enforce separation of power and responsibilities between Azure Stack Hub operator and tenant spaces. 
+As an Azure Stack Hub operator, you can see information about tenant subscriptions, but you can't access the contents of those subscriptions unless you are explicitly added through RBAC by a tenant administrator of that subscription. This allows tenants to enforce separation of power and responsibilities between Azure Stack Hub operator and tenant spaces. 
 
-The exception to this case is a situation where the subscription owner is unable to provide the operator access to it, requiring the administrator to take ownership of the subscription as discussed in [Change the billing owner for an Azure Stack Hub user subscription](azure-stack-change-subscription-owner.md).
+The exception to this case is a situation in which the subscription owner is unable to provide the operator with access to the subscription, which requires the administrator to take ownership of the subscription as discussed in [Change the billing owner for an Azure Stack Hub user subscription](azure-stack-change-subscription-owner.md).
 
 ### Default provider subscription
 

--- a/azure-stack/operator/service-plan-offer-subscription-overview.md
+++ b/azure-stack/operator/service-plan-offer-subscription-overview.md
@@ -99,6 +99,8 @@ Subscriptions let users access your offers. If you're an Azure Stack Hub operato
 
 Users create new subscriptions and get access to existing subscriptions by signing in to Azure Stack Hub. Each subscription represents an association with a single offer. The offer (and its plans and quotas) assigned to one subscription can't be shared with other subscriptions. Each resource that a user creates is associated with one subscription.
 
+As an Azure Stack Hub operator, you are able to see information about tenant subscriptions, however are unable to access the contents of those subscriptions unless explicitly added through RBAC by a tenant administrator of that subscription. This enables tenants to enforce separation of power and responsibilities between Azure Stack Hub operator and tenant spaces.
+
 ### Default provider subscription
 
 The default provider subscription is automatically created when you deploy the ASDK. This subscription can be used to manage Azure Stack Hub, deploy additional resource providers, and create plans and offers for users. For security and licensing reasons, it shouldn't be used to run customer workloads and apps. The quota of the default provider subscription can't be changed.

--- a/azure-stack/operator/service-plan-offer-subscription-overview.md
+++ b/azure-stack/operator/service-plan-offer-subscription-overview.md
@@ -99,7 +99,9 @@ Subscriptions let users access your offers. If you're an Azure Stack Hub operato
 
 Users create new subscriptions and get access to existing subscriptions by signing in to Azure Stack Hub. Each subscription represents an association with a single offer. The offer (and its plans and quotas) assigned to one subscription can't be shared with other subscriptions. Each resource that a user creates is associated with one subscription.
 
-As an Azure Stack Hub operator, you are able to see information about tenant subscriptions, however are unable to access the contents of those subscriptions unless explicitly added through RBAC by a tenant administrator of that subscription. This enables tenants to enforce separation of power and responsibilities between Azure Stack Hub operator and tenant spaces.
+As an Azure Stack Hub operator, you are able to see information about tenant subscriptions, however are unable to access the contents of those subscriptions unless explicitly added through RBAC by a tenant administrator of that subscription. This enables tenants to enforce separation of power and responsibilities between Azure Stack Hub operator and tenant spaces. 
+
+The exception to this case is a situation where the subscription owner is unable to provide the operator access to it, requiring the administrator to take ownership of the subscription as discussed in [Change the billing owner for an Azure Stack Hub user subscription](azure-stack-change-subscription-owner.md).
 
 ### Default provider subscription
 


### PR DESCRIPTION
There is no documentation I can find which notes the security posture enabled by the separation of duties between operator and tenant, this is a particularly powerful capability for service providers, and indeed enterprises where the operator should not be able to access  the contents of tenant subscriptions, and so this should be documented.