### PR TITLE
Fix Get Started link

### DIFF
--- a/azure-stack/hci/toc.yml
+++ b/azure-stack/hci/toc.yml
@@ -5,7 +5,7 @@
   - name: What is Azure Stack HCI?
     href: overview.md
 - name: Get started
-  items:
+  href: get-started.md
 - name: Manage
   items:
   - name: Create volumes


### PR DESCRIPTION
The "Get started" menu is broken here https://docs.microsoft.com/en-us/azure-stack/hci/overview 