### PR TITLE
Fixing bug in heading

### DIFF
--- a/azure-stack/operator/azure-stack-prepare-pki-certs.md
+++ b/azure-stack/operator/azure-stack-prepare-pki-certs.md
@@ -32,7 +32,7 @@ Your system should meet the following prerequisites before packaging PKI certifi
 - Windows 10 or Windows Server 2016 or later
 - Use the same system that generated the Certificate Signing Request (unless you're targeting a certificate prepackaged into PFXs).
 
-## Generate certificate signing requests for new deployments
+## Prepare certificates for deployments
 
 Use these steps to package certificates for new Azure Stack Hub PKI certificates:
 


### PR DESCRIPTION
Changing "Generate certificate signing requests for new deployments" to "Prepare certificates for deployment" to accurately reflect the steps purpose.