### PR TITLE
Changed Get-Item to Get-PfxCertificate

### DIFF
--- a/azure-stack/operator/azure-stack-create-service-principals.md
+++ b/azure-stack/operator/azure-stack-create-service-principals.md
@@ -99,7 +99,7 @@ Once you have a certificate, use the PowerShell script below to register your ap
     # Use the Get-Item cmdlet to retrieve your certificate.
     # If you don't want to use a managed certificate, you can produce a self signed cert for testing purposes: 
     # $Cert = New-SelfSignedCertificate -CertStoreLocation "cert:\CurrentUser\My" -Subject "CN=<YourAppName>" -KeySpec KeyExchange
-    $Cert = Get-Item "<YourCertificateLocation>"
+    $Cert = Get-PfxCertificate -FilePath "<YourCertificateLocation>" # Enter your PFX password when prompted
     
     # Use the privileged endpoint to create the new app registration (and service principal object)
     $SpObject = Invoke-Command -Session $Session -ScriptBlock {New-GraphApplication -Name "<YourAppName>" -ClientCertificates $using:cert}
@@ -168,7 +168,7 @@ Update the certificate credential using PowerShell, substituting your own values
      # Create a self-signed certificate for testing purposes. 
      $NewCert = New-SelfSignedCertificate -CertStoreLocation "cert:\CurrentUser\My" -Subject "CN=<YourAppName>" -KeySpec KeyExchange
      # In production, use Get-Item and a managed certificate instead.
-     # $Cert = Get-Item "<YourCertificateLocation>"
+     # $Cert = Get-PfxCertificate -FilePath "<YourCertificateLocation>" # Enter your PFX password when prompted
 
      # Use the privileged endpoint to update the certificate thumbprint, used by the service principal associated with <AppIdentifier>
      $SpObject = Invoke-Command -Session $Session -ScriptBlock {Set-GraphApplication -ApplicationIdentifier "<AppIdentifier>" -ClientCertificates $using:NewCert}


### PR DESCRIPTION
Changed Get-Item to Get-PfxCertificate. Get-Item creates a System.IO.FileInfo object type. Both New-GraphApplication & Set-GraphApplication are expecting a type of System.Security.Cryptograhy. Get-Item cannot do this, Get-PfxCertificate is needed.