### PR TITLE
changing FullLanguageMode to FullLanguage as mode is not a valid option

### DIFF
--- a/azure-stack/operator/azure-stack-registration.md
+++ b/azure-stack/operator/azure-stack-registration.md
@@ -64,13 +64,13 @@ If you don't have an Azure subscription that meets these requirements, you can [
 
 ### Set the PowerShell language mode
 
-To successfully register Azure Stack Hub, the PowerShell language mode must be set to **FullLanguageMode**.  To verify that the current language mode is set to full, open an elevated PowerShell window and run the following PowerShell cmdlets:
+To successfully register Azure Stack Hub, the PowerShell language mode must be set to **FullLanguage**.  To verify that the current language mode is set to full, open an elevated PowerShell window and run the following PowerShell cmdlets:
 
 ```powershell  
 $ExecutionContext.SessionState.LanguageMode
 ```
 
-Ensure the output returns **FullLanguageMode**. If any other language mode is returned, registration needs to be run on another machine or the language mode needs to be set to **FullLanguageMode** before continuing.
+Ensure the output returns **FullLanguage**. If any other language mode is returned, registration needs to be run on another machine or the language mode needs to be set to **FullLanguage** before continuing.
 
 ### Install PowerShell for Azure Stack Hub
 


### PR DESCRIPTION
Based on:

https://docs.microsoft.com/en-us/azure-stack/asdk/asdk-register?view=azs-2005
and
https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_language_modes?view=powershell-5.1

FullLanguageMode is not a valid option. Fixing to be in line with ASDK doc and to be correct.
Also:
![image](https://user-images.githubusercontent.com/28607803/97990483-e90c3e80-1dd7-11eb-903f-c24dad1ad775.png)

