### PR TITLE
fix image link to show the latest bigger image

### DIFF
--- a/azure-stack/operator/create-add-on-plan.md
+++ b/azure-stack/operator/create-add-on-plan.md
@@ -47,7 +47,7 @@ Add-on plans are [created the same way](azure-stack-create-plan.md) as a base pl
 
 6. Review the list of add-on plans included with the offer to verify that the new add-on plan is listed.
 
-    ![Screenshot that shows a list of add-on plans to review in Azure Stack administrator portal.](media/create-add-on-plan/add-on4.png "Create add-on plan")](media/create-add-on-plan/add-on4lg.png#lightbox)
+    ![Screenshot that shows a list of add-on plans to review in Azure Stack administrator portal.](media/create-add-on-plan/add-on4lg.png)
 ::: moniker-end
 
 ::: moniker range="<=azs-1901"


### PR DESCRIPTION
Currently it displays the smaller image and has got additional broken link:
![image](https://user-images.githubusercontent.com/28607803/98092381-815cfe80-1e7e-11eb-86e6-ead3e3f64cc6.png)

Fixing to put the correct image and clean up the doc.