### PR TITLE
Update ASDK post deploy steps

### DIFF
--- a/azure-stack/asdk/asdk-post-deploy.md
+++ b/azure-stack/asdk/asdk-post-deploy.md
@@ -40,7 +40,7 @@ You can install the latest Azure Stack PowerShell module with or without interne
 
 
   ```powershell  
-  # Update the current PowerShellGet module to latest versionrequired to support PreRelease modules
+  # Update the current PowerShellGet module to latest version, required to support PreRelease modules
   Install-Module -Name PowerShellGet -Force
 
   Get-Module -Name Azs.* -ListAvailable | Uninstall-Module -Force -Verbose

--- a/azure-stack/asdk/asdk-post-deploy.md
+++ b/azure-stack/asdk/asdk-post-deploy.md
@@ -40,6 +40,9 @@ You can install the latest Azure Stack PowerShell module with or without interne
 
 
   ```powershell  
+  # Update the current PowerShellGet module to latest versionrequired to support PreRelease modules
+  Install-Module -Name PowerShellGet -Force
+
   Get-Module -Name Azs.* -ListAvailable | Uninstall-Module -Force -Verbose
   Get-Module -Name Azure* -ListAvailable | Uninstall-Module -Force -Verbose
 


### PR DESCRIPTION
Because the Az modules are preview you must use a later version of the PowerShellGet module than the one that ships with the OS. That step was missing.  This is what happens without this step

PS C:\Windows\system32> Install-Module -Name Az.BootStrapper
PackageManagement\Install-Package : No match was found for the specified search criteria and module name
'Az.BootStrapper'. Try Get-PSRepository to see all available registered module repositories.
At C:\Program Files\WindowsPowerShell\Modules\PowerShellGet\1.0.0.1\PSModule.psm1:1809 char:21
+ ...          $null = PackageManagement\Install-Package @PSBoundParameters
+                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (Microsoft.Power....InstallPackage:InstallPackage) [Install-Package], Ex
   ception
    + FullyQualifiedErrorId : NoMatchFoundForCriteria,Microsoft.PowerShell.PackageManagement.Cmdlets.InstallPackage

 