### PR TITLE
Remove internal secret rotation variables

### DIFF
--- a/azure-stack/operator/azure-stack-rotate-secrets.md
+++ b/azure-stack/operator/azure-stack-rotate-secrets.md
@@ -237,9 +237,6 @@ Complete the following steps to rotate internal secrets:
     $PEPSession = New-PSSession -ComputerName <IP_address_of_ERCS_Machine> -Credential $PEPCreds -ConfigurationName "PrivilegedEndpoint"
 
     # Run Secret Rotation
-    $CertPassword = ConvertTo-SecureString "<Cert_Password>" -AsPlainText -Force
-    $CertShareCreds = Get-Credential
-    $CertSharePath = "<Network_Path_Of_CertShare>"
     Invoke-Command -Session $PEPSession -ScriptBlock {
         Start-SecretRotation -Internal
     }


### PR DESCRIPTION
Variables for cert password and cert share aren't used by internal secret rotation. These are only required when doing external secret rotation.