### PR TITLE
Removing NIC stuff.

### DIFF
--- a/azure-stack/hci/concepts/system-requirements.md
+++ b/azure-stack/hci/concepts/system-requirements.md
@@ -78,18 +78,6 @@ For more information about preparing for using SDN in Azure Stack HCI, see [Plan
 
 This section provides network hardware requirements for NICs and physical switches when planning for a SDN environment.
 
-#### Network interface cards (NICs)
-
-The NICs that you use in your Hyper-V hosts and storage hosts require specific capabilities to achieve the best performance.
-
-Remote Direct Memory Access (RDMA) is a kernel bypass technique that makes it possible to transfer large amounts of data without using the host CPU, which frees the CPU to perform other work. Switch Embedded Teaming (SET) is an alternative NIC Teaming solution that you can use in environments that include Hyper-V and the SDN stack. SET integrates some NIC Teaming functionality into the Hyper-V Virtual Switch.
-
-For more information, see [Remote Direct Memory Access (RDMA) and Switch Embedded Teaming (SET)](/windows-server/virtualization/hyper-v-virtual-switch/rdma-and-switch-embedded-teaming).
-
-To account for the overhead in tenant virtual network traffic caused by VXLAN or NVGRE encapsulation headers, the maximum transmission unit (MTU) of the Layer-2 fabric network (switches and hosts) must be set to greater than or equal to 1674 bytes \(including Layer-2 Ethernet headers\).
-
-NICs that support the new *EncapOverhead* advanced adapter keyword set the MTU automatically through the Network Controller Host Agent. NICs that do not support the new *EncapOverhead* keyword need to set the MTU size manually on each physical host using the *JumboPacket* \(or equivalent\) keyword.
-
 #### Switches and routers
 
 When selecting a physical switch and router for your SDN environment, make sure it supports the following set of capabilities:


### PR DESCRIPTION
All of this is included in the link above which is the appropriate location for this documentation. Additionally, encapoverhead is a requirement for all standard and premium network cards rendering this section redundant.

@v-dasis - FYI