### PR TITLE
Azure Stack DNS allows AAAA records

### DIFF
--- a/azure-stack/user/azure-stack-network-differences.md
+++ b/azure-stack/user/azure-stack-network-differences.md
@@ -25,7 +25,6 @@ This article provides an overview of the unique considerations for Azure Stack H
 | Service | Feature | Azure (global) | Azure Stack Hub |
 |--------------------------|----------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
 | DNS | Multi-tenant DNS | Supported | Not yet supported |
-|  | DNS AAAA records | Supported | Not supported |
 |  | DNS zones per subscription | 100 (default)<br>Can be increased on request. | 100 |
 |  | DNS record sets per zone | 5000 (default)<br>Can be increased on request. | 5000 |
 |  | Name servers for zone delegation | Azure provides four name servers for each user (tenant) zone that is created. | Azure Stack Hub provides two name servers for each user (tenant) zone that is created. |


### PR DESCRIPTION
Just tested on AZSH stamp 2008:

 - Create an Azure DNS Zone in an Azure Stack Hub subscription such as `contoso.com`
 - Create a recordset for `ipv6.contoso.com` and select `AAAA` record and a value of `2021::dead`
 - Note the NS servers of the zone (`azs-ns01`...)
 - Open a command prompt and type `nslookup ipv6.contoso.com azs-ns01`...
 - Result: the AAAA record is resolved successfully

Even if Azure Stack Hub VMs or VNET don't support IPv6, Azure Stack DNS service can have AAAA records to resolve external services