### PR TITLE
(Azure CXP Team) resolves MicrosoftDocs/azure-stack-docs#1760

### DIFF
--- a/azure-stack/aks-hci/secrets-store-csi-driver.md
+++ b/azure-stack/aks-hci/secrets-store-csi-driver.md
@@ -38,7 +38,7 @@ Get-AksHciCredential -name mycluster
 To install the Secrets Store CSI Driver, run the following Helm command:
 
 ```powershell
-helm repo add csi-secrets-store-provider-azure https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/chartsy
+helm repo add csi-secrets-store-provider-azure https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts
 ```
 
 The following command installs both the Secrets Store CSI Driver and the Azure Key Vault provider:


### PR DESCRIPTION
Typo in the helm command
Chartsy -> chart