### PR TITLE
Now AKS on HCI supports up to 8 physical servers

### DIFF
--- a/azure-stack/aks-hci/concepts-support.md
+++ b/azure-stack/aks-hci/concepts-support.md
@@ -17,7 +17,7 @@ Azure Kubernetes Service on Azure Stack HCI deployments that exceed the followin
 
 | Resource                     | Maximum |
 | ---------------------------- | --------|
-| Physical servers per cluster | 4       |
+| Physical servers per cluster | 8       |
 | Kubernetes Clusters          | 4       |
 | Total number of VMs          | 200     |
 


### PR DESCRIPTION
The following blog post mentioned that AKS on HCI supports up to 8 physical servers.

https://techcommunity.microsoft.com/t5/azure-stack-blog/aks-on-azure-stack-hci-november-2021-update/ba-p/2995180
> **Increasing physical node support from 4 nodes to 8 nodes**
> AKS on AzureStack HCI supports deployments on up to 8 physical nodes which makes it easier to run AKS on AzureStack deployments with a wider variety of Azure Stack HCI hardware and to scale up your deployment with confidence.