### PR TITLE
Fix: Corrected parameter as the one provided does not exist

### DIFF
--- a/azure-stack/operator/remote-support.md
+++ b/azure-stack/operator/remote-support.md
@@ -69,7 +69,7 @@ Enable-RemoteSupport -AccessLevel Diagnostics -ExpireInMinutes 1440
 
 Use **ExpireInMinutes** parameter to set the duration of the session. In the example, consent expires in 1,440 minutes (one day). After one day, remote access cannot be established.
 
-You can set **ExpireInDay** a minimum duration of 60 minutes (one hour) and a maximum of 20,160 minutes (14 days).
+You can set **ExpireInMinutes** a minimum duration of 60 minutes (one hour) and a maximum of 20,160 minutes (14 days).
 
 If duration is not defined the remote session will expire in 480 (8 hours) by default.
 


### PR DESCRIPTION
***ExpireInDay** is not a parameter in this function, and even if it was, it would have to be **ExpireInDays**.

This change will make it a lot less ambiguous as to what is being said in the documentation.