### PR TITLE
Update tutorial-private-forest.md

### DIFF
--- a/azure-stack/hci/deploy/tutorial-private-forest.md
+++ b/azure-stack/hci/deploy/tutorial-private-forest.md
@@ -134,7 +134,7 @@ Creating the parent disks can take as long as 1-2 hours, although it can take mu
 
 ### Create the Azure Stack HCI parent disk
 
-Download the [Convert-WindowsImage.ps1 function](https://raw.githubusercontent.com/microsoft/MSLab/master/Tools/Convert-WindowsImage.ps1) to the C:\Lab\wslab_xxx\ParentDisks folder as **CreateParentDisk.ps1**. Then run **CreateParentDisk.ps1** as administrator. Choose the Azure Stack HCI ISO from C:\Labs\Isos, and accept the default name and size.
+Download the [Convert-WindowsImage.ps1 function](https://raw.githubusercontent.com/microsoft/MSLab/master/Tools/Convert-WindowsImage.ps1) to the C:\Lab\wslab_xxx\ParentDisks folder as **Convert-WindowsImage.ps1**. Then run **CreateParentDisk.ps1** as administrator. Choose the Azure Stack HCI ISO from C:\Labs\Isos, and accept the default name and size.
 
 Creating the parent disk will take a while. When the operation is complete, you’ll be prompted to start the VMs. Don’t start them yet - type **N**.
 


### PR DESCRIPTION
Function file is required to be saved with its original name and not as CreateParentDisk.ps1. As the later file already exists and required to be executed after function file download.