### PR TITLE
Fixing the work directory path

### DIFF
--- a/azure-stack/hci/manage/troubleshoot-arc-enabled-vms.md
+++ b/azure-stack/hci/manage/troubleshoot-arc-enabled-vms.md
@@ -28,7 +28,7 @@ Get-ArcHCILogs -workDirectory <path>
 
 The `workDirectory` is located under the following path: 
 
-`$csv_path\ResourceBridge\kvatoken.tok`
+`$csv_path\ResourceBridge`
 
 Please provide the absolute file path name. Optionally, you can provide the `-logDir` parameter, to provide the path to the directory in which generated logs will be saved. If you don't provide either the path or parameter, the location defaults to the current working directory.
 


### PR DESCRIPTION
The work directory path was mistakenly pointing to the token file. It is actually supposed to be pointing to the parent folder.