### PR TITLE
Exclude -AzureVMResourceId parameter

### DIFF
--- a/azure-stack/user/vm-update-management.md
+++ b/azure-stack/user/vm-update-management.md
@@ -122,7 +122,7 @@ $startTime = ([DateTime]::Now).AddMinutes(10)
 
 $s = New-AzAutomationSchedule -ResourceGroupName mygroup -AutomationAccountName myaccount -Name myupdateconfig -Description test-OneTime -OneTime -StartTime $startTime -ForUpdateConfiguration
 
-New-AzAutomationSoftwareUpdateConfiguration  -ResourceGroupName $rg -AutomationAccountName $aa -Schedule $s -Windows -AzureVMResourceId $azureVMIdsW -NonAzureComputer $nonAzurecomputers -Duration (New-TimeSpan -Hours 2) -IncludedUpdateClassification Security,UpdateRollup -ExcludedKbNumber KB01,KB02 -IncludedKbNumber KB100
+New-AzAutomationSoftwareUpdateConfiguration  -ResourceGroupName $rg -AutomationAccountName $aa -Schedule $s -Windows -NonAzureComputer $nonAzurecomputers -Duration (New-TimeSpan -Hours 2) -IncludedUpdateClassification Security,UpdateRollup -ExcludedKbNumber KB01,KB02 -IncludedKbNumber KB100
 ```
 ### [AzureRM modules](#tab/azurerm)
 
@@ -133,7 +133,7 @@ $startTime = ([DateTime]::Now).AddMinutes(10)
 
 $s = New-AzureRMAutomationSchedule -ResourceGroupName mygroup -AutomationAccountName myaccount -Name myupdateconfig -Description test-OneTime -OneTime -StartTime $startTime -ForUpdateConfiguration
 
-New-AzureRMAutomationSoftwareUpdateConfiguration  -ResourceGroupName $rg -AutomationAccountName $aa -Schedule $s -Windows -AzureVMResourceId $azureVMIdsW -NonAzureComputer $nonAzurecomputers -Duration (New-TimeSpan -Hours 2) -IncludedUpdateClassification Security,UpdateRollup -ExcludedKbNumber KB01,KB02 -IncludedKbNumber KB100
+New-AzureRMAutomationSoftwareUpdateConfiguration  -ResourceGroupName $rg -AutomationAccountName $aa -Schedule $s -Windows -NonAzureComputer $nonAzurecomputers -Duration (New-TimeSpan -Hours 2) -IncludedUpdateClassification Security,UpdateRollup -ExcludedKbNumber KB01,KB02 -IncludedKbNumber KB100
 ```
 
 ---


### PR DESCRIPTION
Have had colab come to my team from Azure Monitoring for failed deployment of _New-AzureAutomationSoftwareUpdateConfigurations_ - customers attempting to add Azure Stack Hub VMs are including _"-AzureVMResourceId $azureVMIdsW"_ parameter and variable from documentation, causing deployment to fail. 

As documentation is in the **context** of Azure Stack Hub VMs / None Public Azure VMs, suggest it would be best to remove this parameter (as only relevant for AzureVMs) from the docs example scripts.