### PR TITLE
Proxy Server walkthrough link is broken

### DIFF
--- a/azure-stack/aks-hci/kubernetes-walkthrough-powershell.md
+++ b/azure-stack/aks-hci/kubernetes-walkthrough-powershell.md
@@ -20,7 +20,7 @@ In this quickstart, you'll learn the setup for an Azure Kubernetes Service (AKS)
 
 > [!NOTE]
 > - If you have pre-staged cluster service objects and DNS records, see [deploy an AKS host with prestaged cluster service objects and DNS records using PowerShell](prestage-cluster-service-host-create.md).
-> - If you have a proxy server, see [Set up an AKS host and deploy a workload cluster using PowerShell and a proxy server](kubernetes-walkthrough-powershell.md).
+> - If you have a proxy server, see [Set up an AKS host and deploy a workload cluster using PowerShell and a proxy server](set-proxy-settings.md).
 
 ## Before you begin
 


### PR DESCRIPTION
The link points to the same location and should point to set-proxy-settings.md or https://docs.microsoft.com/en-us/azure-stack/aks-hci/set-proxy-settings#configure-an-aks-host-for-a-proxy-server-with-basic-authentication

Edit link changed