### PR TITLE
Update deploy-arc-resource-bridge-using-command-line.md

### DIFF
--- a/azure-stack/hci/manage/deploy-arc-resource-bridge-using-command-line.md
+++ b/azure-stack/hci/manage/deploy-arc-resource-bridge-using-command-line.md
@@ -68,7 +68,7 @@ To prepare to install Azure Arc Resource Bridge on an Azure Stack HCI cluster an
    
    **controlPlaneIP**: The IP address that is used for the load balancer in the Arc Resource Bridge. The IP address must be in the same subnet as the DHCP scope and must be excluded from the DHCP scope to avoid IP address conflicts.
    
-   **csv_path**: A CSV volume path that is accessible from all servers of the cluster. This is used for caching OS images used for the Azure Arc Resource Bridge. It also stores temporary configuration files during installation and cloud agent configuration files after installation; for example, `C:\ClusterStorage\contosoVol\`.
+   **csv_path**: A CSV volume path that is accessible from all servers of the cluster. This is used for caching OS images used for the Azure Arc Resource Bridge. It also stores temporary configuration files during installation and cloud agent configuration files after installation; for example, `C:\ClusterStorage\contosoVol`.
    
    **vLanID** (optional): vLAN identifier.
    


### PR DESCRIPTION
Removing backslash at end of example of csv_path.  It results in an issue when creating VM from Azure Arc it fails to attach VHDX to VM, this seems to cause error 0x80070035 "An unexpected error occurred: The network path was not found." because there will be a \\ in the imagestore path.