### PR TITLE
adding warning note for QM SA Lifetime for site-to-site vpns

### DIFF
--- a/azure-stack/user/azure-stack-vpn-s2s.md
+++ b/azure-stack/user/azure-stack-vpn-s2s.md
@@ -79,6 +79,8 @@ The following table lists the supported cryptographic algorithms and key strengt
 | QM SA Lifetime                                       | (Optional: default values are used if not specified)<br />                         Seconds (integer; min. 300/default 27000 seconds)<br />                         KBytes (integer; min. 1024/default 102400000 KBytes) |
 | Traffic Selector                                     | Policy-based Traffic Selectors are not supported in Azure Stack Hub.         |
 
+[!NOTE] Setting the QM SA Lifetime too low will require unnecessary re-keying degrading performance.
+
 \* These parameters are only available in builds 2002 and later.
 
 - Your on-premises VPN device configuration must match or contain the following algorithms and parameters that you specify on the Azure IPsec/IKE policy:

--- a/azure-stack/user/azure-stack-vpn-s2s.md
+++ b/azure-stack/user/azure-stack-vpn-s2s.md
@@ -79,7 +79,8 @@ The following table lists the supported cryptographic algorithms and key strengt
 | QM SA Lifetime                                       | (Optional: default values are used if not specified)<br />                         Seconds (integer; min. 300/default 27000 seconds)<br />                         KBytes (integer; min. 1024/default 102400000 KBytes) |
 | Traffic Selector                                     | Policy-based Traffic Selectors are not supported in Azure Stack Hub.         |
 
-[!NOTE] Setting the QM SA lifetime too low requires unnecessary re-keying, which can degrade performance.
+> [!NOTE] 
+> Setting the QM SA lifetime too low requires unnecessary rekeying, which can degrade performance.
 
 \* These parameters are only available in builds 2002 and later.
 

--- a/azure-stack/user/azure-stack-vpn-s2s.md
+++ b/azure-stack/user/azure-stack-vpn-s2s.md
@@ -79,7 +79,7 @@ The following table lists the supported cryptographic algorithms and key strengt
 | QM SA Lifetime                                       | (Optional: default values are used if not specified)<br />                         Seconds (integer; min. 300/default 27000 seconds)<br />                         KBytes (integer; min. 1024/default 102400000 KBytes) |
 | Traffic Selector                                     | Policy-based Traffic Selectors are not supported in Azure Stack Hub.         |
 
-[!NOTE] Setting the QM SA Lifetime too low will require unnecessary re-keying degrading performance.
+[!NOTE] Setting the QM SA lifetime too low requires unnecessary re-keying, which can degrade performance.
 
 \* These parameters are only available in builds 2002 and later.
 


### PR DESCRIPTION
An additional warning note should be added to ensure that others understand the implications of using the default value which may not be immediately clear. 