### PR TITLE
Fix cmdlet name as it is missing a verb

### DIFF
--- a/azure-stack/includes/get-pki-certs-csrs-new-cn-only.md
+++ b/azure-stack/includes/get-pki-certs-csrs-new-cn-only.md
@@ -13,18 +13,18 @@ ms.lastreviewed: 04/29/2022
    - For a **production deployment environment**, the first script will generate CSRs for deployment certificates, the second will generate CSRs for any optional PaaS services you've installed:
 
       ```powershell
-      New-AzsCertificateSigningRequest*** -certificateType Deployment -RegionName $regionName -FQDN $externalFQDN -OutputRequestPath $OutputDirectory -IdentitySystem $IdentitySystem
+      New-AzsCertificateSigningRequest -certificateType Deployment -RegionName $regionName -FQDN $externalFQDN -OutputRequestPath $OutputDirectory -IdentitySystem $IdentitySystem
       ```
 
       ```powershell
       # App Services
-      New-AzsCertificateSigningRequest* -CertificateType AppServices -RegionName $regionName -FQDN $externalFQDN -OutputRequestPath $OutputDirectory
+      New-AzsCertificateSigningRequest -CertificateType AppServices -RegionName $regionName -FQDN $externalFQDN -OutputRequestPath $OutputDirectory
 
       # DBAdapter (SQL/MySQL)
-      New-AzsCertificateSigningRequest* -CertificateType DbAdapter -RegionName $regionName -FQDN $externalFQDN -OutputRequestPath $OutputDirectory
+      New-AzsCertificateSigningRequest -CertificateType DbAdapter -RegionName $regionName -FQDN $externalFQDN -OutputRequestPath $OutputDirectory
 
       # EventHubs
-      New-AzsCertificateSigningRequest* -CertificateType EventHubs -RegionName $regionName -FQDN $externalFQDN -OutputRequestPath $OutputDirectory
+      New-AzsCertificateSigningRequest -CertificateType EventHubs -RegionName $regionName -FQDN $externalFQDN -OutputRequestPath $OutputDirectory
       ```
 
    - For a **development and test environment**, to generate a single CSR with multiple-subject alternative names, add the `-RequestType SingleCSR` parameter and value.
@@ -33,5 +33,5 @@ ms.lastreviewed: 04/29/2022
       > We do *not* recommend using this approach for production environments.
 
       ```powershell
-      New-AzsCertificateSigningRequest* -certificateType Deployment -RegionName $regionName -FQDN $externalFQDN -RequestType SingleCSR -OutputRequestPath $OutputDirectory -IdentitySystem $IdentitySystem
+      New-AzsCertificateSigningRequest -certificateType Deployment -RegionName $regionName -FQDN $externalFQDN -RequestType SingleCSR -OutputRequestPath $OutputDirectory -IdentitySystem $IdentitySystem
       ```

--- a/azure-stack/includes/get-pki-certs-csrs-new-cn-only.md
+++ b/azure-stack/includes/get-pki-certs-csrs-new-cn-only.md
@@ -13,7 +13,7 @@ ms.lastreviewed: 04/29/2022
    - For a **production deployment environment**, the first script will generate CSRs for deployment certificates, the second will generate CSRs for any optional PaaS services you've installed:
 
       ```powershell
-      New-AzsCertificateSigningRequest -certificateType Deployment -RegionName $regionName -FQDN $externalFQDN -OutputRequestPath $OutputDirectory -IdentitySystem $IdentitySystem
+      New-AzsCertificateSigningRequest -CertificateType Deployment -RegionName $regionName -FQDN $externalFQDN -OutputRequestPath $OutputDirectory -IdentitySystem $IdentitySystem
       ```
 
       ```powershell
@@ -33,5 +33,5 @@ ms.lastreviewed: 04/29/2022
       > We do *not* recommend using this approach for production environments.
 
       ```powershell
-      New-AzsCertificateSigningRequest -certificateType Deployment -RegionName $regionName -FQDN $externalFQDN -RequestType SingleCSR -OutputRequestPath $OutputDirectory -IdentitySystem $IdentitySystem
+      New-AzsCertificateSigningRequest -CertificateType Deployment -RegionName $regionName -FQDN $externalFQDN -RequestType SingleCSR -OutputRequestPath $OutputDirectory -IdentitySystem $IdentitySystem
       ```

--- a/azure-stack/includes/get-pki-certs-csrs-new-cn-only.md
+++ b/azure-stack/includes/get-pki-certs-csrs-new-cn-only.md
@@ -7,31 +7,31 @@ ms.date: 04/29/2022
 ms.reviewer: bryanla
 ms.lastreviewed: 04/29/2022
 ---
-   
+
 1. Generate CSRs by completing one of the following:
 
    - For a **production deployment environment**, the first script will generate CSRs for deployment certificates, the second will generate CSRs for any optional PaaS services you've installed:
 
-      ```powershell  
-      AzsCertificateSigningRequest -certificateType Deployment -RegionName $regionName -FQDN $externalFQDN -OutputRequestPath $OutputDirectory -IdentitySystem $IdentitySystem
+      ```powershell
+      New-AzsCertificateSigningRequest*** -certificateType Deployment -RegionName $regionName -FQDN $externalFQDN -OutputRequestPath $OutputDirectory -IdentitySystem $IdentitySystem
       ```
 
-      ```powershell  
+      ```powershell
       # App Services
-      AzsCertificateSigningRequest -CertificateType AppServices -RegionName $regionName -FQDN $externalFQDN -OutputRequestPath $OutputDirectory
+      New-AzsCertificateSigningRequest* -CertificateType AppServices -RegionName $regionName -FQDN $externalFQDN -OutputRequestPath $OutputDirectory
 
       # DBAdapter (SQL/MySQL)
-      AzsCertificateSigningRequest -CertificateType DbAdapter -RegionName $regionName -FQDN $externalFQDN -OutputRequestPath $OutputDirectory
+      New-AzsCertificateSigningRequest* -CertificateType DbAdapter -RegionName $regionName -FQDN $externalFQDN -OutputRequestPath $OutputDirectory
 
       # EventHubs
-      AzsCertificateSigningRequest -CertificateType EventHubs -RegionName $regionName -FQDN $externalFQDN -OutputRequestPath $OutputDirectory
+      New-AzsCertificateSigningRequest* -CertificateType EventHubs -RegionName $regionName -FQDN $externalFQDN -OutputRequestPath $OutputDirectory
       ```
 
-   - For a **development and test environment**, to generate a single CSR with multiple-subject alternative names, add the `-RequestType SingleCSR` parameter and value. 
+   - For a **development and test environment**, to generate a single CSR with multiple-subject alternative names, add the `-RequestType SingleCSR` parameter and value.
 
       > [!IMPORTANT]
       > We do *not* recommend using this approach for production environments.
 
-      ```powershell  
-      AzsCertificateSigningRequest -certificateType Deployment -RegionName $regionName -FQDN $externalFQDN -RequestType SingleCSR -OutputRequestPath $OutputDirectory -IdentitySystem $IdentitySystem
+      ```powershell
+      New-AzsCertificateSigningRequest* -certificateType Deployment -RegionName $regionName -FQDN $externalFQDN -RequestType SingleCSR -OutputRequestPath $OutputDirectory -IdentitySystem $IdentitySystem
       ```


### PR DESCRIPTION
The cmdlet name is missing a verb.
This will resolve the issue.
Cmdlet is from -> https://www.powershellgallery.com/packages/Microsoft.AzureStack.ReadinessChecker/1.2100.1963.864/Content/CertificateValidation%5CMicrosoft.AzureStack.PublicCertificateRequest.psm1

Also fixed some trailing spaces.