### PR TITLE
Helm chart repository URL has changed

### DIFF
--- a/azure-stack/aks-hci/secrets-store-csi-driver.md
+++ b/azure-stack/aks-hci/secrets-store-csi-driver.md
@@ -46,7 +46,7 @@ Get-AksHciCredential -name mycluster
 To install the Secrets Store CSI Driver, run the following Helm command:
 
 ```powershell
-helm repo add csi-secrets-store-provider-azure https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts
+helm repo add csi-secrets-store-provider-azure https://azure.github.io/secrets-store-csi-driver-provider-azure/charts
 ```
 
 The following command installs both the Secrets Store CSI Driver and the Azure Key Vault provider:


### PR DESCRIPTION
https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/charts/csi-secrets-store-provider-azure

> The helm chart repository URL has changed from https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts to https://azure.github.io/secrets-store-csi-driver-provider-azure/charts.