### PR TITLE
Remove mention of cluster set support for HCI

### DIFF
--- a/azure-stack/hci/concepts/system-requirements.md
+++ b/azure-stack/hci/concepts/system-requirements.md
@@ -17,7 +17,7 @@ Use this topic to assess system requirements for servers, storage, and networkin
 
 ## Server requirements
 
-A standard Azure Stack HCI cluster requires a minimum of one server and a maximum of 16 servers; however, clusters can be combined using cluster sets to create an HCI platform of hundreds of nodes.
+A standard Azure Stack HCI cluster requires a minimum of one server and a maximum of 16 servers.
 
 Keep the following in mind for various types of Azure Stack HCI deployments:
 


### PR DESCRIPTION
Cutting this part from line 20-21 since HCI does not support clusters sets> (; however, clusters can be combined using cluster sets to create an HCI platform of hundreds of nodes)