### PR TITLE
Use AZURE_STORAGE_ACCOUNT_NAME to avoid confusion

### DIFF
--- a/azure-stack/aks-hci/backup-workload-cluster.md
+++ b/azure-stack/aks-hci/backup-workload-cluster.md
@@ -60,9 +60,9 @@ Use the following steps to deploy and configure Velero:
    To create the storage account, run the following command:
 
    ```azurecli
-   AZURE_STORAGE_ACCOUNT_ID="velero$(uuidgen | cut -d '-' -f5 | tr '[A-Z]' '[a-z]')"
+   AZURE_STORAGE_ACCOUNT_NAME="velero$(uuidgen | cut -d '-' -f5 | tr '[A-Z]' '[a-z]')"
    az storage account create \
-      --name $AZURE_STORAGE_ACCOUNT_ID \
+      --name $AZURE_STORAGE_ACCOUNT_NAME \
       --resource-group $AZURE_BACKUP_RESOURCE_GROUP \
       --sku Standard_GRS \
       --encryption-services blob \
@@ -75,7 +75,7 @@ Use the following steps to deploy and configure Velero:
    
    ```azurecli
    BLOB_CONTAINER=velero
-   az storage container create -n $BLOB_CONTAINER --public-access off --account-name $AZURE_STORAGE_ACCOUNT_ID
+   az storage container create -n $BLOB_CONTAINER --public-access off --account-name $AZURE_STORAGE_ACCOUNT_NAME
    ```
 
 3. [Set permissions for Velero](https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure#set-permissions-for-velero) and create a service principal.

--- a/azure-stack/aks-hci/backup-workload-cluster.md
+++ b/azure-stack/aks-hci/backup-workload-cluster.md
@@ -132,7 +132,7 @@ Use the following steps to deploy and configure Velero:
       --plugins velero/velero-plugin-for-microsoft-azure:v1.3.0 \
       --bucket $BLOB_CONTAINER \
       --secret-file ./credentials-velero \
-      --backup-location-config resourceGroup=$AZURE_BACKUP_RESOURCE_GROUP,storageAccount=$AZURE_STORAGE_ACCOUNT_ID[,subscriptionId=$AZURE_BACKUP_SUBSCRIPTION_ID] \
+      --backup-location-config resourceGroup=$AZURE_BACKUP_RESOURCE_GROUP,storageAccount=$AZURE_STORAGE_ACCOUNT_NAME[,subscriptionId=$AZURE_BACKUP_SUBSCRIPTION_ID] \
       --use-restic
    ```
 


### PR DESCRIPTION
### Changes
Change `AZURE_STORAGE_ACCOUNT_ID` to `AZURE_STORAGE_ACCOUNT_NAME`

### Reason
When reusing pre-created storage account to practise, reader may confuse the storage account id and name. It's actually storage account name.