### PR TITLE
Update emergency-vm-access.md

### DIFF
--- a/azure-stack/user/emergency-vm-access.md
+++ b/azure-stack/user/emergency-vm-access.md
@@ -43,7 +43,7 @@ $TenantID = "TenantID"
 $TenantSubscriptionId = "Tenant Subscription ID"
 
 $tenantSubscriptionSettings = @{
-    TenantSubscriptionId = $tenantSubscriptionId
+    TenantSubscriptionId = [string]$tenantSubscriptionId
 }
 
 # Add environment & authenticate
@@ -71,7 +71,7 @@ $TenantID = "TenantID"
 $TenantSubscriptionId = "Tenant Subscription ID"
 
 $tenantSubscriptionSettings = @{
-    TenantSubscriptionId = $tenantSubscriptionId
+    TenantSubscriptionId = [string]$tenantSubscriptionId
 }
 
 #Add environment & authenticate


### PR DESCRIPTION
Adding [string] into the script of ## Operator enables a user subscription for EVA part to enable operators to convert values entered via Read-Host to be accepted as string and parse into the later command. Confirmed from local lab.