### PR TITLE
Added a note to advising to maintain same BIOS Config

### DIFF
--- a/azure-stack/hci/deploy/register-with-azure.md
+++ b/azure-stack/hci/deploy/register-with-azure.md
@@ -240,7 +240,7 @@ After the cluster is registered, you can see `ConnectionStatus` and the `LastCon
 If you exceed the maximum period of offline operation, `ConnectionStatus` will show `OutOfPolicy`.
 
 > [!NOTE]
-   > BIOS \ UEFI Firmware configurations on each HCI Cluster node hardware must be same. Any nodes with different BIOS configurations compared to the majority may show `ConnectionStatus` as `OutOfPolicy`.
+> BIOS\UEFI Firmware configuration on each HCI Cluster node hardware must be the same. Any nodes with different BIOS configurations compared to the majority may show **ConnectionStatus** as **OutOfPolicy**.
 
 ## Register a cluster using SPN for Arc onboarding
 

--- a/azure-stack/hci/deploy/register-with-azure.md
+++ b/azure-stack/hci/deploy/register-with-azure.md
@@ -239,6 +239,9 @@ After the cluster is registered, you can see `ConnectionStatus` and the `LastCon
 
 If you exceed the maximum period of offline operation, `ConnectionStatus` will show `OutOfPolicy`.
 
+> [!NOTE]
+   > BIOS \ UEFI Firmware configurations on each HCI Cluster node hardware must be same. Any nodes with different BIOS configurations compared to the majority may show `ConnectionStatus` as `OutOfPolicy`.
+
 ## Register a cluster using SPN for Arc onboarding
 
 Before registration, make sure the prerequisites are met: the HCI cluster must exist, internet access and firewall ports are configured correctly, and the user registering the cluster has either the "contributor" role assigned for the subscription which is used for the cluster registration, or has the following list of permissions if a custom role is assigned:

--- a/azure-stack/hci/deploy/register-with-azure.md
+++ b/azure-stack/hci/deploy/register-with-azure.md
@@ -240,7 +240,7 @@ After the cluster is registered, you can see `ConnectionStatus` and the `LastCon
 If you exceed the maximum period of offline operation, `ConnectionStatus` will show `OutOfPolicy`.
 
 > [!NOTE]
-> BIOS\UEFI Firmware configuration on each HCI Cluster node hardware must be the same. Any nodes with different BIOS configurations compared to the majority may show **ConnectionStatus** as **OutOfPolicy**.
+> BIOS\UEFI Firmware configuration must be the same on each HCI cluster node's hardware. Any nodes with different BIOS configurations compared to the majority may show **ConnectionStatus** as **OutOfPolicy**.
 
 ## Register a cluster using SPN for Arc onboarding
 


### PR DESCRIPTION
> [!NOTE]
   > BIOS \ UEFI Firmware configurations on each HCI Cluster node hardware must be same. Any nodes with different BIOS configurations compared to the majority may show `ConnectionStatus` as `OutOfPolicy`.