### PR TITLE
Updating secret.yaml to avoid confusion

### DIFF
--- a/AKS-Hybrid/prepare-windows-nodes-gmsa.md
+++ b/AKS-Hybrid/prepare-windows-nodes-gmsa.md
@@ -98,7 +98,7 @@ Before completing the steps below, make sure the **AksHci** PowerShell module is
       namespace: <secret under namespace other than the default>
    type: Opaque
    stringData:
-      domain: <domain name, for example: akshcitest>
+      domain: <domain name, for example: akshcitest.com>
       username: <domain user who can retrieve the gMSA password>
       password: <password>
    ```


### PR DESCRIPTION
Customers can mistake the domain field to be a NetBIOS name instead of a DNS name, which would fail gMSA from retrieving the credentials. Making it clear by updating example that the domain name must be in a DNS name format.