### PR TITLE
Fix typo as without the hyphen the command would not work

### DIFF
--- a/azure-stack/hci/concepts/host-network-requirements.md
+++ b/azure-stack/hci/concepts/host-network-requirements.md
@@ -262,7 +262,7 @@ The following assumptions are made for this example:
         - If the available bandwidth for Live Migration is >= 5 Gbps, and the network adapters are capable, use RDMA. Use the following cmdlet to do so:
 
             ```Powershell
-            Set-VMHost VirtualMachineMigrationPerformanceOption SMB
+            Set-VMHost -VirtualMachineMigrationPerformanceOption SMB
             ```
 
         - If the available bandwidth for Live Migration is < 5 Gbps, use compression to reduce blackout times. Use the following cmdlet to do so:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/28607803/207685216-2c46e93f-34fb-4657-ac6f-745c442d0412.png)
Clearly, you can see there is a typo here.

Documentation reference -> https://learn.microsoft.com/en-us/powershell/module/hyper-v/set-vmhost?view=windowsserver2022-ps#-virtualmachinemigrationperformanceoption

This is a parameter so it needs a hyphen.