### PR TITLE
Clarifying domain for gMSA to avoid confusion

### DIFF
--- a/AKS-Hybrid/prepare-windows-nodes-gmsa.md
+++ b/AKS-Hybrid/prepare-windows-nodes-gmsa.md
@@ -98,7 +98,7 @@ Before completing the steps below, make sure the **AksHci** PowerShell module is
       namespace: <secret under namespace other than the default>
    type: Opaque
    stringData:
-      domain: <domain name, for example: akshcitest.com>
+      domain: <FQDN of the domain, for example: akshcitest.com>
       username: <domain user who can retrieve the gMSA password>
       password: <password>
    ```


### PR DESCRIPTION
Gotten feedback from users that using the domain name, will not always work. Must use FQDN, which results in using Kerberos and that's supported.