### PR TITLE
Az CLI certificate setup: compute sha1 hash using cer file

### DIFF
--- a/azure-stack/asdk/asdk-cli.md
+++ b/azure-stack/asdk/asdk-cli.md
@@ -58,9 +58,6 @@ Export the CA root certificate. To export the ASDK root certificate in PEM forma
 
     Write-Host "Exporting certificate"
     Export-Certificate -Type CERT -FilePath root.cer -Cert $root
-
-    Write-Host "Converting certificate to PEM format"
-    certutil -encode root.cer root.pem
     ```
 
 4. Copy the certificate to your local machine.
@@ -125,17 +122,21 @@ To use Azure CLI with the ASDK, you must trust the CA root certificate on your r
 2. Trust the Azure Stack Hub CA root certificate by appending it to the existing Python certificate.
 
     ```powershell
-    $pemFile = "<Fully qualified path to the PEM certificate exported from `
-    your Azure Stack Hub and saved. For example: C:\Users\user1\Downloads\root.pem."
+    $cerFile = "<Fully qualified path to the cer certificate exported from `
+    your Azure Stack Hub and saved. For example: C:\Users\user1\Downloads\root.cer"
     $pythonCertStore = <result from step 4>
 
+    $cerDir = Split-Path -Parent $cerFile
+    $pemFile = "$cerDir\root.pem"
+    Write-Host "Converting certificate to PEM format at $pemFile"
+    certutil -encode $cerFile $pemFile
     $root = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2
     $root.Import($pemFile)
 
     Write-Host "Extracting required information from the cert file"
-    $md5Hash    = (Get-FileHash -Path $pemFile -Algorithm MD5).Hash.ToLower()
-    $sha1Hash   = (Get-FileHash -Path $pemFile -Algorithm SHA1).Hash.ToLower()
-    $sha256Hash = (Get-FileHash -Path $pemFile -Algorithm SHA256).Hash.ToLower()
+    $md5Hash    = (Get-FileHash -Path $cerFile -Algorithm MD5).Hash.ToLower()
+    $sha1Hash   = (Get-FileHash -Path $cerFile -Algorithm SHA1).Hash.ToLower()
+    $sha256Hash = (Get-FileHash -Path $cerFile -Algorithm SHA256).Hash.ToLower()
 
     $issuerEntry  = [string]::Format("# Issuer: {0}", $root.Issuer)
     $subjectEntry = [string]::Format("# Subject: {0}", $root.Subject)

--- a/azure-stack/asdk/asdk-cli.md
+++ b/azure-stack/asdk/asdk-cli.md
@@ -133,6 +133,10 @@ To use Azure CLI with the ASDK, you must trust the CA root certificate on your r
     $root = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2
     $root.Import($pemFile)
 
+    # X509Certificate2.Thumbprint calculates SHA1 hash of the public key. You can get sha1 of the pem file by using openssl, 
+    # e.g. openssl x509 -noout -fingerprint -sha1 -inform pem -in ./root.pem
+    # Alternatively, 'Get-FileHash' gives the same value (without ':') for the corresponding cer file
+    # Since the thumbprint is a unique value for the certificate, it is commonly used to find a particular certificate in a certificate store
     Write-Host "Extracting required information from the cert file"
     $md5Hash    = (Get-FileHash -Path $cerFile -Algorithm MD5).Hash.ToLower()
     $sha1Hash   = (Get-FileHash -Path $cerFile -Algorithm SHA1).Hash.ToLower()


### PR DESCRIPTION
sha1 hash of pem file doesn't match with thumbprint of root certificate.
This change uses cer file instead to compute sha1 hash. This matches thumbprint of root certificate and hence this entry can be used to validate correct certificate is added/exists in the python cert store.

```
PS C:\> (Get-FileHash -Path $cerFile -Algorithm SHA1).Hash.ToLower()
9269b30eabcd8a551ecac007f8ce6ceb66232798

PS C:\> $root.Thumbprint
9269B30EABCD8A551ECAC007F8CE6CEB66232798
```