### PR TITLE
Update hci-recommended-urls-table.md

### DIFF
--- a/azure-stack/includes/hci-recommended-urls-table.md
+++ b/azure-stack/includes/hci-recommended-urls-table.md
@@ -18,7 +18,7 @@ ms.lastreviewed: 04/19/2022
 | Microsoft Update | wustat.windows.com    | 80   | For Microsoft Update, which allows the OS to receive updates. |
 | Microsoft Update | ntservicepack.microsoft.com    | 80   | For Microsoft Update, which allows the OS to receive updates.  |
 | Microsoft Update | go.microsoft.com   | 80   | For Microsoft Update, which allows the OS to receive updates.  |
-| Microsoft Update | dl.delivery.mp.microsoft.com    | 443  | For Microsoft Update, which allows the OS to receive updates.  |
+| Microsoft Update | *.delivery.mp.microsoft.com    | 443  | For Microsoft Update, which allows the OS to receive updates.  |
 | Microsoft Update | *.windowsupdate.microsoft.com   | 80, 443   | For Microsoft Update, which allows the OS to receive updates. |
 | Microsoft Update | *.update.microsoft.com   | 80, 443   | For Microsoft Update, which allows the OS to receive updates.  |
 | Microsoft Update | *.windowsupdate.com | 80 | For Microsoft Update, which allows the OS to receive updates.|


### PR DESCRIPTION
Unable to retrieve Windows Updates. In the WindowsUpdate.log we saw that node could not communicate with end point: 'https://fe3cr.delivery.mp.microsoft.com/ClientWebService/client.asmx'

Maybe doc could be updated from:
| Microsoft Update | dl.delivery.mp.microsoft.com    | 443  | For Microsoft Update, which allows the OS to receive updates.  |
To:
| Microsoft Update | *.delivery.mp.microsoft.com    | 443  | For Microsoft Update, which allows the OS to receive updates.  |

Log snippet:
2023/01/10 14:14:31.9388814 14216 9796  WebServices     WS error: There was an error communicating with the endpoint at 'https://fe3cr.delivery.mp.microsoft.com/ClientWebService/client.asmx'.
2023/01/10 14:14:31.9388826 14216 9796  WebServices     WS error: The given proxy cannot be reached.

Thanks!