### PR TITLE
Fix billing models for Get-AzsRegistrationToken cmdlet

### DIFF
--- a/azure-stack/operator/azure-stack-registration.md
+++ b/azure-stack/operator/azure-stack-registration.md
@@ -687,7 +687,7 @@ Get-AzsRegistrationToken [-PrivilegedEndpointCredential] <PSCredential> [-Privil
 | AzureContext | PSObject |  |
 | ResourceGroupName | String |  |
 | ResourceGroupLocation | String |  |
-| BillingModel | String | The billing model that your subscription uses. Allowed values for this parameter are: Capacity, PayAsYouUse, and Development. |
+| BillingModel | String | The billing model that your subscription uses. Allowed values for this parameter are: Capacity, Custom, and Development. |
 | MarketplaceSyndicationEnabled | True/False |  |
 | UsageReportingEnabled | True/False | Azure Stack Hub reports usage metrics by default. Operators with capacity uses or supporting a disconnected environment need to turn off usage reporting. Allowed values for this parameter are: True, False. |
 | AgreementNumber | String |  |


### PR DESCRIPTION
Whilst recently working on the registration code I found out that the `Get-AzsRegistrationToken` cmdlet only allows for Capacity, Development, and Custom BillingModles.
That makes total sense as it is meant to be used for disconnected scenarios and those cannot use PayAsYouUse model :-)

For reference, the command comes from `RegisterWithAzure.psm1` file ->
https://github.com/Azure/AzureStack-Tools/blob/az/Registration/RegisterWithAzure.psm1#L639
![image](https://user-images.githubusercontent.com/28607803/214024999-7699c33c-9fd2-437a-88e1-31a8f354e677.png)

The statement in the documentation is very confusing as it led me to believe that maybe the disconnected method would work for connected systems - clearly it does not :-) and it was never meant to :-)

This PR will hopefully make this a lot less confusing for people :-)
