### PR TITLE
Added ASDK note regarding no support for SQL RP

### DIFF
--- a/azure-stack/operator/azure-stack-sql-resource-provider-deploy.md
+++ b/azure-stack/operator/azure-stack-sql-resource-provider-deploy.md
@@ -30,6 +30,9 @@ The SQL resource provider runs as a service on a special Add-on RP Windows Serve
 > [!IMPORTANT]
 > Only the resource provider should create items on servers that host SQL or MySQL. Items created on a host server that aren't created by the resource provider are unsupported, and may result in a mismatched state.
 
+> [!IMPORTANT]
+> The V2.x SQL/MySQL Resource Provider uses the Deployment Resource Provider (DRP) installation mechanism which isn't supported on ASDK (2206). Therefore, the V2.x SQL/MySQL Resource Provider isn't supported on ASDK.
+
 ## Prerequisites
 
 [!INCLUDE [Common RP prerequisites](../includes/resource-provider-prerequisites.md)]

--- a/azure-stack/operator/azure-stack-sql-resource-provider-deploy.md
+++ b/azure-stack/operator/azure-stack-sql-resource-provider-deploy.md
@@ -31,7 +31,7 @@ The SQL resource provider runs as a service on a special Add-on RP Windows Serve
 > Only the resource provider should create items on servers that host SQL or MySQL. Items created on a host server that aren't created by the resource provider are unsupported, and may result in a mismatched state.
 
 > [!IMPORTANT]
-> The V2.x SQL/MySQL Resource Provider uses the Deployment Resource Provider (DRP) installation mechanism which isn't supported on ASDK (2206). Therefore, the V2.x SQL/MySQL Resource Provider isn't supported on ASDK.
+> The V2.x SQL/MySQL Resource Provider uses the Deployment Resource Provider (DRP) installation mechanism which isn't supported on ASDK. Therefore, the V2.x SQL/MySQL Resource Provider isn't supported on ASDK.
 
 ## Prerequisites
 

--- a/azure-stack/operator/azure-stack-sql-resource-provider-deploy.md
+++ b/azure-stack/operator/azure-stack-sql-resource-provider-deploy.md
@@ -31,7 +31,7 @@ The SQL resource provider runs as a service on a special Add-on RP Windows Serve
 > Only the resource provider should create items on servers that host SQL or MySQL. Items created on a host server that aren't created by the resource provider are unsupported, and may result in a mismatched state.
 
 > [!IMPORTANT]
-> The V2.x SQL/MySQL Resource Provider uses the Deployment Resource Provider (DRP) installation mechanism which isn't supported on ASDK. Therefore, the V2.x SQL/MySQL Resource Provider isn't supported on ASDK.
+> The V2.x SQL/MySQL resource provider uses the Deployment Resource Provider (DRP) installation mechanism, which isn't supported on the ASDK. Therefore, the V2.x SQL/MySQL resource provider isn't supported on the ASDK.
 
 ## Prerequisites
 


### PR DESCRIPTION
SQL RP/MySQL RP v2 leverages DRP, and DRP (Deployment RP) isn’t supported on ASDK. This is why the  “resource provider” tab as highlighted in Marketplace Management page cannot be seen.