### PR TITLE
Update delete-vm.md

### DIFF
--- a/azure-stack/user/delete-vm.md
+++ b/azure-stack/user/delete-vm.md
@@ -4,9 +4,9 @@ description: How to delete a VM (virtual machine) with dependencies on Azure Sta
 author: sethmanheim
 
 ms.topic: how-to
-ms.date: 5/20/2021
+ms.date: 02/13/2023
 ms.author: sethm
-ms.reviewer: kivenkat
+ms.reviewer: thoroet
 ms.lastreviewed: 5/20/2021
 
 # Intent: As an Azure Stack user, I want to delete a VM with dependencies in Azure Stack Hub.
@@ -14,32 +14,31 @@ ms.lastreviewed: 5/20/2021
 
 ---
 
-# How to delete a VM (virtual machine) with dependencies on Azure Stack Hub
+# How to delete a virtual machine with dependencies on Azure Stack Hub
 
-In this article, you can find the steps to remove a VM and its dependencies from Azure Stack Hub.
+This article describes how to remove a virtual machine (VM) and its dependencies from Azure Stack Hub.
 
-If you remove a VM from Azure Stack Hub, the component dependencies--that is data disks, virtual network interfaces, and diagnostic containers--will remain in the resource group. These items won't be automatically deleted along with your OS disc. You can follow the steps in this article to successfully remove your OS disc and component dependencies.
+If you remove a VM from Azure Stack Hub, the component dependencies--that is, data disks, virtual network interfaces, and diagnostic containers--remain in the resource group. These items won't be automatically deleted along with your OS disk. Follow the steps in this article to successfully remove your OS disk and component dependencies.
 
-## Delete a VM overview
+## Delete a VM
 
-When you create a new VM, you typically create a new resource group and put all the dependencies in that resource group. When you want to delete the VM and all of its dependencies, you can delete the resource group. The Azure Resource Manager will successfully delete the dependencies. There are times when you cannot delete the resource group to remove the VM. For example, the VM may contain resources that are not dependencies of the VM that you would like to keep.
+When you create a new VM, typically you create a new resource group and put all the dependencies in that resource group. When you want to delete the VM and all of its dependencies, you can delete the resource group. The Azure Resource Manager will successfully delete the dependencies. However, there are times when you cannot delete the resource group to remove the VM. For example, the VM might contain resources that are not dependencies of the VM that you want to keep.
 
-## Delete a VM with dependencies (UnManaged Disks)
+## Delete a VM with dependencies (unmanaged disks)
 
-You can use the portal or PowerShell to remove your VM and its dependencies.
+You can use the Azure portal or PowerShell to remove your VM and its dependencies.
 
 ### [With the portal](#tab/portal)
 
-In the case where you cannot delete the resource group, either the dependencies are not in the same resource group, or there are other resources, follow the steps below:
-
-Please remember that the steps included to remove the Disks are for UnManaged Disks
+If you cannot delete the resource group, either the dependencies are not in the same resource group, or there are other resources. Follow these steps:
 
 1. Open the Azure Stack user portal.
 
-2. Select **Virtual machines**. Find your virtual machine, and then select your machine to open the Virtual machine blade.  
-![Delete VM with dependencies](./media/delete-vm/azure-stack-hub-delete-vm-portal.png)  
+2. Select **Virtual machines**. Find your virtual machine, and then select your machine to open the virtual machine blade.
 
-3. Make a note of (write down) the resource group that contains the VM and VM dependencies.
+   ![Delete VM with dependencies](./media/delete-vm/azure-stack-hub-delete-vm-portal.png)  
+
+3. Make a note of the resource group that contains the VM and VM dependencies.
 
 4. Select **Networking** and make a note of the networking interface.
 
@@ -47,20 +46,20 @@ Please remember that the steps included to remove the Disks are for UnManaged Di
 
 6. Return to the **Virtual machine** blade, and select **Delete**.
 
-7. Type `yes` to confirm the delete and select **Delete**.
+7. Type **yes** to confirm the delete and then select **Delete**.
 
-7. Select **Resource groups** and then select the resource group.
+7. Select **Resource groups**, then select the resource group.
 
 8. Delete the dependencies by manually selecting the items you have noted. For each item, select **Delete**.
-    1. Type `yes` to confirm the delete and select **Delete**.
+    1. Type `yes` to confirm the delete and then select **Delete**.
     2. Wait for the resource to delete completely.
     3. You can then delete the next dependency.
 
 ### [Az modules](#tab/ps-az)
 
-In the case where you cannot delete the resource group, either the dependencies are not in the same resource group, or there are other resources, follow these steps.
+If you cannot delete the resource group, either the dependencies are not in the same resource group, or there are other resources. Follow these steps:
 
-Connect to your Azure Stack Hub environment, and then update the following variables with your VM name and resource group. For instructions on connecting to your PowerShell session to Azure Stack Hub, see [Connect to Azure Stack Hub with PowerShell as a user](azure-stack-powershell-configure-user.md).
+Connect to your Azure Stack Hub environment, and then update the following variables with your VM name and resource group. For instructions on connecting your PowerShell session to Azure Stack Hub, see [Connect to Azure Stack Hub with PowerShell as a user](azure-stack-powershell-configure-user.md).
 
 ```powershell
 $machineName = 'VM_TO_DELETE'
@@ -68,21 +67,21 @@ $resGroupName = 'RESOURCE_GROUP'
 $machine = Get-AzVM -Name $machineName -ResourceGroupName $resGroupName
 ```
 
-Retrieve the VM information and name of dependencies. In the same session, run the following cmdlets:
+Retrieve the VM information and name of dependencies. In the same session, run the following script:
 
 ```powershell
- $azResParams = @{
- 'ResourceName' = $machineName
- 'ResourceType' = 'Microsoft.Compute/virtualMachines'
-     'ResourceGroupName' = $resGroupName
- }
- $vmRes = Get-AzResource @azResParams
- $vmId = $vmRes.Properties.VmId
+$azResParams = @{
+'ResourceName' = $machineName
+'ResourceType' = 'Microsoft.Compute/virtualMachines'
+    'ResourceGroupName' = $resGroupName
+}
+$vmRes = Get-AzResource @azResParams
+$vmId = $vmRes.Properties.VmId
 ```
 
-Delete the boot diagnostic storage container. If your machine name is shorter than 9 characters, you will need to change the index to your string length in the substring when creating the `$diagContainer` variable. 
+Delete the boot diagnostic storage container. If your machine name is shorter than 9 characters, change the index to your string length in the substring when creating the `$diagContainer` variable. 
 
-In the same session, run the following cmdlets:
+In the same session, run the following commands:
 
 ```powershell
 $container = [regex]::match($machine.DiagnosticsProfile.bootDiagnostics.storageUri, '^http[s]?://(.+?)\.').groups[1].value
@@ -94,13 +93,13 @@ $storeParams = @{
 Get-AzStorageAccount @storeParams | Get-AzStorageContainer | where { $_.Name-eq $diagContainer } | Remove-AzStorageContainer -Force
 ```
 
-Remove the virtual network interface.
+Remove the virtual network interface:
 
 ```powershell
 $machine | Remove-AzNetworkInterface -Force
 ```
 
-Delete the operating system disk.
+Delete the operating system disk:
 
 ```powershell
 $osVhdUri = $machine.StorageProfile.OSDisk.Vhd.Uri
@@ -109,7 +108,7 @@ $osDiskStorageAcct = Get-AzStorageAccount | where { $_.StorageAccountName -eq $o
 $osDiskStorageAcct | Remove-AzStorageBlob -Container $osDiskConName -Blob $osVhdUri.Split('/')[-1] -Confirm:$true
 ```
 
-Remove the data disks attached to your VM.
+Remove the data disks attached to your VM:
 
 ```powershell
 if ($machine.StorageProfile.DataDisks.Name.Count -gt 0)
@@ -132,9 +131,9 @@ $machine | Remove-AzVM -Force
 ```
 ### [AzureRM modules](#tab/ps-azureRM)
 
-In the case where you cannot delete the resource group, either the dependencies are not in the same resource group, or there are other resources, follow these steps.
+If you cannot delete the resource group, either the dependencies are not in the same resource group, or there are other resources. Follow these steps:
 
-Connect to your Azure Stack Hub environment, and then update the following variables with your VM name and resource group. For instructions on connecting to your PowerShell session to Azure Stack Hub, see [Connect to Azure Stack Hub with PowerShell as a user](azure-stack-powershell-configure-user.md).
+Connect to your Azure Stack Hub environment, then update the following variables with your VM name and resource group. For instructions on connecting your PowerShell session to Azure Stack Hub, see [Connect to Azure Stack Hub with PowerShell as a user](azure-stack-powershell-configure-user.md).
 
 ```powershell
 $machineName = 'VM_TO_DELETE'
@@ -142,19 +141,19 @@ $resGroupName = 'RESOURCE_GROUP'
 $machine = Get-AzureRmVM -Name $machineName -ResourceGroupName $resGroupName
 ```
 
-Retrieve the VM information and name of dependencies. In the same session, run the following cmdlets:
+Retrieve the VM information and name of dependencies. In the same session, run the following commands:
 
 ```powershell
- $azResParams = @{
- 'ResourceName' = $machineName
- 'ResourceType' = 'Microsoft.Compute/virtualMachines'
-     'ResourceGroupName' = $resGroupName
- }
- $vmRes = Get-AzureRmResource @azResParams
- $vmId = $vmRes.Properties.VmId
+$azResParams = @{
+'ResourceName' = $machineName
+'ResourceType' = 'Microsoft.Compute/virtualMachines'
+    'ResourceGroupName' = $resGroupName
+}
+$vmRes = Get-AzureRmResource @azResParams
+$vmId = $vmRes.Properties.VmId
 ```
 
-Delete the boot diagnostic storage container. If your machine name is shorter than 9 characters, you will need to change the index to your string length in the substring when creating the `$diagContainer` variable. 
+Delete the boot diagnostic storage container. If your machine name is shorter than 9 characters, change the index to your string length in the substring when creating the `$diagContainer` variable. 
 
 In the same session, run the following cmdlets:
 
@@ -168,13 +167,13 @@ $storeParams = @{
 Get-AzureRmStorageAccount @storeParams | Get-AzureStorageContainer | where { $_.Name-eq $diagContainer } | Remove-AzureStorageContainer -Force
 ```
 
-Remove the virtual network interface.
+Remove the virtual network interface:
 
 ```powershell
 $machine | Remove-AzureRmNetworkInterface -Force
 ```
 
-Delete the operating system disk.
+Delete the operating system disk:
 
 ```powershell
 $osVhdUri = $machine.StorageProfile.OSDisk.Vhd.Uri
@@ -183,7 +182,7 @@ $osDiskStorageAcct = Get-AzureRmStorageAccount | where { $_.StorageAccountName -
 $osDiskStorageAcct | Remove-AzureStorageBlob -Container $osDiskConName -Blob $osVhdUri.Split('/')[-1]
 ```
 
-Remove the data disks attached to your VM.
+Remove the data disks attached to your VM:
 
 ```powershell
 if ($machine.DataDiskNames.Count -gt 0)
@@ -197,7 +196,7 @@ if ($machine.DataDiskNames.Count -gt 0)
  }
 ```
 
-Finally, delete the VM. The cmdlet takes some time to run. You can audit the components attached to the VM by reviewing the VM object in PowerShell. To review the object, just refer to the variable that contains the VM object. Type `$machine`.
+Finally, delete the VM. The cmdlet takes some time to run. You can audit the components attached to the VM by reviewing the VM object in PowerShell. To review the object, refer to the variable that contains the VM object. Type `$machine`.
 
 To delete the VM, in the same session, run the following cmdlets:
 


### PR DESCRIPTION
There are several changes that I suggest to this article: I've tested the code in one of my labs, feel free to ping me and I can show.

1. This article applies to delete resources from VM's, however does not mention that this PowerShell commands only work on UnManaged disks. If a customer executes this steps using Managed disks, this won't work.

2. Line 109
  - I suggest adding a confirmation, so that customer ack that he's going to delete the OS Disk

3. Line 115
  - If statement will not work, since "$Machine.DatadiskNames.Count" does not exist (will always be 0)
  - Changed it to  "$machine.StorageProfile.DataDisks.Name.Count", that will count the right number of DataDisks

4.  Line 120
  - "Get-AzStorageAccount" does not contain any property named "Name", modified code to instead include property "StorageAccountName"

4. Line 121
  - Added also a confirmation so that customer knows the UnManage data disks he's deleting