### PR TITLE
correct Health Settings default value

### DIFF
--- a/azure-stack/hci/manage/health-service-settings.md
+++ b/azure-stack/hci/manage/health-service-settings.md
@@ -54,7 +54,7 @@ Some commonly modified settings are listed below, along with their default value
 "System.Storage.PhysicalDisk.AutoRetire.OnLostCommunication.Enabled"       = True
 "System.Storage.PhysicalDisk.AutoRetire.OnUnresponsive.Enabled"            = True
 "System.Storage.PhysicalDisk.AutoRetire.DelayMs"                           = 900000 (i.e. 15 minutes)
-"System.Storage.PhysicalDisk.Unresponsive.Reset.CountResetIntervalSeconds" = 360 (i.e. 60 minutes)
+"System.Storage.PhysicalDisk.Unresponsive.Reset.CountResetIntervalSeconds" = 3600 (i.e. 60 minutes)
 "System.Storage.PhysicalDisk.Unresponsive.Reset.CountAllowed"              = 3
 ```
 


### PR DESCRIPTION
System.Storage.PhysicalDisk.Unresponsive.Reset.CountResetIntervalSeconds is 3600 by default, which is 60 minutes /1 hour.

Get-StorageSubSystem Cluster* | Get-StorageHealthSetting -Name "System.Storage.PhysicalDisk.Unresponsive.Reset.CountResetIntervalSeconds"

Name                                                                     Value PSComputerName
----                                                                     ----- --------------
System.Storage.PhysicalDisk.Unresponsive.Reset.CountResetIntervalSeconds 3600