### PR TITLE
Fix the key of auto scaler profile configuration

### DIFF
--- a/AKS-Hybrid/work-with-autoscaler-profiles.md
+++ b/AKS-Hybrid/work-with-autoscaler-profiles.md
@@ -35,24 +35,24 @@ The default profile consists of the default values below. You can update the fol
 
 | Setting | Description | Default value |
 | --- | --- | --- |
-| min-node-Count | The minimum node count that the node pool to which this profile is assigned can scale down to. | 0 |
-| max-node-Count | The maximum node count that the node pool to which this profile is assigned can scale up to. | 1 |
+| min-node-count | The minimum node count that the node pool to which this profile is assigned can scale down to. | 0 |
+| max-node-count | The maximum node count that the node pool to which this profile is assigned can scale up to. | 1 |
 | scan-interval | How often cluster is reevaluated for scale up or down. | 10 seconds |
-| scale-downdelay-afteradd | How long after scale up that scale down evaluation resumes. | 10 minutes |
-| scale-downdelay-afterdelete | How long after node deletion that scale down evaluation resumes. | scaninterval |
-| scale-downdelay-afterfailure | How long after scale down failure that scale down evaluation resumes. | 3 minutes |
-| scale-downunneededtime | How long a node should be unneeded before it's eligible for scale down. | 10 minutes |
-| scale-downunreadytime | How long an unready node should be unneeded before it's eligible for scale down. | 20 minutes |
-| scale-downutilizationthreshold | Node utilization level, defined as sum of requested resources divided by capacity, below which a node can be considered for scale down. | 0.5 |
-| max-gracefulterminationsec | Maximum number of seconds the cluster autoscaler waits for pod termination when trying to scale down a node. | 600 seconds |
-| balancesimilarnodegroups | Detects similar node pools and balances the number of nodes between them. | false |
-| expander | Type of node pool expander to be used in scale up. Possible values: most-pods, random, least-waste, priority. | random |
-| skip-nodeswith-localstorage | If true cluster autoscaler will never delete nodes with pods with local storage, for example, EmptyDir or HostPath. | true |
-| skip-nodeswithsystempods | If true cluster autoscaler will never delete nodes with pods from kube-system (except for DaemonSet or mirror pods). | true |
-| max-emptybulk-delete | Maximum number of empty nodes that can be deleted at the same time. | 10 nodes |
-| new-podscale-updelay | For scenarios like burst/batch scale where you don't want CA to act before the kubernetes scheduler could schedule all the pods, you can tell CA to ignore unscheduled pods before they're a certain age. | 0 seconds |
-| max-totalunreadypercentage | Maximum percentage of unready nodes in the cluster. After this percentage is exceeded, CA halts operations. | 45% |
-| max-nodeprovisiontime | Maximum time the autoscaler waits for a node to be provisioned. | 15 minutes |
+| scale-down-delay-after-add | How long after scale up that scale down evaluation resumes. | 10 minutes |
+| scale-down-delay-after-delete | How long after node deletion that scale down evaluation resumes. | scaninterval |
+| scale-down-delay-after-failure | How long after scale down failure that scale down evaluation resumes. | 3 minutes |
+| scale-down-unneeded-time | How long a node should be unneeded before it's eligible for scale down. | 10 minutes |
+| scale-down-unready-time | How long an unready node should be unneeded before it's eligible for scale down. | 20 minutes |
+| scale-down-utilization-threshold | Node utilization level, defined as sum of requested resources divided by capacity, below which a node can be considered for scale down. | 0.5 |
+| max-graceful-termination-sec | Maximum number of seconds the cluster autoscaler waits for pod termination when trying to scale down a node. | 600 seconds |
+| balance-similar-node-groups | Detects similar node pools and balances the number of nodes between them. | false |
+| expander | Type of node pool [expander](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-expanders) to be used in scale up. Possible values: most-pods, random, least-waste, priority. | random |
+| skip-nodes-with-local-storage | If true cluster autoscaler will never delete nodes with pods with local storage, for example, EmptyDir or HostPath. | true |
+| skip-nodes-with-system-pods | If true cluster autoscaler will never delete nodes with pods from kube-system (except for DaemonSet or mirror pods). | true |
+| max-empty-bulk-delete | Maximum number of empty nodes that can be deleted at the same time. | 10 nodes |
+| new-pod-scale-up-delay | For scenarios like burst/batch scale where you don't want CA to act before the kubernetes scheduler could schedule all the pods, you can tell CA to ignore unscheduled pods before they're a certain age. | 0 seconds |
+| max-total-unready-percentage | Maximum percentage of unready nodes in the cluster. After this percentage is exceeded, CA halts operations. | 45% |
+| max-node-provision-time | Maximum time the autoscaler waits for a node to be provisioned. | 15 minutes |
 
 ## Notes on autoscaler configuration
 


### PR DESCRIPTION
- Some keys does not have correct hyphens between words. Users should be able to copy and paste the key listed here for command
  `New-AksHciAutoScalerProfile`.
  <img width="538" alt="image" src="https://user-images.githubusercontent.com/107901166/219529133-f4875dc8-fa71-4aeb-a1dc-bcdeb4413d09.png">

- Add a link to see the detail about expander types. AKS' document is doing the same thing.
  <img width="1269" alt="image" src="https://user-images.githubusercontent.com/107901166/219541901-0a6a4322-70df-4988-9e50-5ca4e0ae9904.png">


