### PR TITLE
Remove ClientId and replace it with GUID as the name does not include ClientId

### DIFF
--- a/azure-stack/operator/give-app-access-to-resources.md
+++ b/azure-stack/operator/give-app-access-to-resources.md
@@ -471,7 +471,7 @@ The type of resource you choose also establishes the *access scope* for the app.
 3. Select the **Access Control (IAM)** page, which is universal across all resources that support RBAC.
 4. Select **+ Add**
 5. Under **Role**, pick the role you wish to assign to the app.
-6. Under **Select**, search for your app using a full or partial Application Name. During registration, the Application Name is generated as *Azurestack-\<YourAppName\>-\<ClientId\>*. For example, if you used an application name of *App2*, and ClientId *2bbe67d8-3fdb-4b62-87cf-cc41dd4344ff* was assigned during creation, the full name would be  *Azurestack-App2-2bbe67d8-3fdb-4b62-87cf-cc41dd4344ff*. You can search for either the exact string, or a portion, like *Azurestack* or *Azurestack-App2*.
+6. Under **Select**, search for your app using a full or partial Application Name. During registration, the Application Name is generated as *Azurestack-\<YourAppName\>-\<GUID\>*. For example, if you used an application name of *App2*, and GUID *2bbe67d8-3fdb-4b62-87cf-cc41dd4344ff* was assigned during creation, the full name would be *Azurestack-App2-2bbe67d8-3fdb-4b62-87cf-cc41dd4344ff*. You can search for either the exact string, or a portion, like *Azurestack* or *Azurestack-App2*.
 7. Once you find the app, select it and it will show under **Selected members**.
 8. Select **Save** to finish assigning the role.
 


### PR DESCRIPTION
This again seems like a small change, but in reality, it is MASSIVE.

It sent me on a goose chase for over a day trying to figure out why ClientId does not match.

It turns out, it was never meant to match and the code inside PEP just puts `New-Guid` in the name, and it is not at all the ClientId of the Service Principal.

This is exceedingly misleading for number of reasons:

1. When you search and you saved your ClientId (which you should have done as you will need it for future authentications) and want to find your App - it will not be found because it is *NOT* in the name at all.
2. More importantly, when you do automation and you wanted an easy way to "extract" ClientId from the App name - well you cannot so you have to be a lot more creative on how to store and then retrieve said ClientId. This may not be a problem for everyone, as you probably just store it in credential vault of some sorts, but sometimes you have MANY Stacks and those Apps are specific to each of them, it is a bit of a tricky situation when you try to code around it and you were led to believe that you can derive that information from the App name.


Looking closer at this very document - we can see that it was never true.

Exhibit A:
![image](https://user-images.githubusercontent.com/28607803/223675606-193e2ef2-501b-43be-9af7-bf9ba2f72c58.png)

Exhibit B:
![image](https://user-images.githubusercontent.com/28607803/223676262-cc879568-d1cb-48d0-98fc-f4af88156c02.png)

I have done my own testing and hopefully this screenshot will seal the deal :-) I can also provide the code that creates the App, but we do not need to go there ;-)

Exhibit C:
![image](https://user-images.githubusercontent.com/28607803/223676654-e5ad6b87-cbed-4f8f-bd4f-39e5ca0962a6.png)

All in all, I hope we can amend the docs to fix the seemingly tiny mistake :-) Like I said, it could be a very costly and confusing mistake to make if you rely on the App Name to contain ClientId.

Happy Azure Stacking :-)