### PR TITLE
fix PS variable WorkingDir

### DIFF
--- a/AKS-Hybrid/aks-hybrid-preview-azure-vm.md
+++ b/AKS-Hybrid/aks-hybrid-preview-azure-vm.md
@@ -207,7 +207,7 @@ $location=<Azure location. Can be "eastus", "westeurope", "westus3", or "southce
 ```
 
 ```PowerShell
-$workingDir = "V:\AKS-HCI\WorkDir"
+$workingDir = "V:\AKS-HCI\WorkingDir"
 $arcAppName="arc-resource-bridge"
 $configFilePath= $workingDir + "\hci-appliance.yaml"
 $arcExtnName = "aks-hybrid-ext"


### PR DESCRIPTION
The working directory created in the previous steps is: `WorkingDir` instead of `WorkDir`. As a result, an error will occur:

![image](https://user-images.githubusercontent.com/52395211/224923876-c07a63c6-20b2-4df0-9c53-6e998f571f15.png)
