### PR TITLE
remove SkipPublisherCheck switch

### DIFF
--- a/AKS-Hybrid/includes/install-akshci-ps.md
+++ b/AKS-Hybrid/includes/install-akshci-ps.md
@@ -18,7 +18,7 @@ Follow these steps on all nodes in your Azure Stack HCI cluster or Windows Serve
 
    ```powershell  
    Install-PackageProvider -Name NuGet -Force 
-   Install-Module -Name PowershellGet -Force -Confirm:$false -SkipPublisherCheck
+   Install-Module -Name PowershellGet -Force -Confirm:$false
    ```
 
    You must close all existing PowerShell windows again to ensure that loaded modules are refreshed. Do not continue to the next step until you have closed all open PowerShell windows.


### PR DESCRIPTION
It is not necessary to enable the switch.

> [-SkipPublisherCheck](https://learn.microsoft.com/powershell/module/powershellget/install-module#-skippublishercheck)
> Allows you to install a newer version of a module that already exists on your computer. For example, when an existing module is digitally signed by a trusted publisher but the new version isn't digitally signed by a trusted publisher.