### PR TITLE
consolidate app removal after unregister step

### DIFF
--- a/azure-stack/operator/azure-stack-hub-decommission.md
+++ b/azure-stack/operator/azure-stack-hub-decommission.md
@@ -27,36 +27,6 @@ Follow these steps in a connected (Azure AD) environment:
 1. Disable multi-tenancy by removing secondary directories: [Unregister a guest directory](enable-multitenancy.md#unregister-a-guest-directory).
 1. Verify any additional guest directories have been removed: [Retrieve identity health report](enable-multitenancy.md#retrieve-azure-stack-hub-identity-health-report).
 1. Remove any tenant registrations for usage billing: [Remove a tenant mapping](azure-stack-csp-ref-operations.md#remove-a-tenant-mapping).
-1. Generate a list of Azure AD app registrations for Azure Stack Hub:
-   1. [Connect to your Azure Stack environment with Azure PowerShell](azure-stack-powershell-configure-admin.md#connect-with-azure-ad).
-   1. In the same PowerShell instance as the previous step, run the following script to export a list of all app registration IDs.
-
-   ```powershell
-   $context = Get-AzContext
-   if (!$context.Subscription){
-       @"
-       # Connect To Azure Stack Admin Azure Resource Manager endpoint first https://learn.microsoft.com/azure-stack/operator/azure-stack-powershell-configure-admin#connect-with-azure-ad
-       "@ | Write-Host -ForegroundColor:Red
-   }
-
-   "Getting access token for tenant {0}" -f $context.Subscription.TenantID | Write-Host -ForegroundColor Green
-
-   $azureRmProfile = [Microsoft.Azure.Commands.Common.Authentication.Abstractions.AzureRmProfileProvider]::Instance.Profile
-   $profileClient = New-Object Microsoft.Azure.Commands.ResourceManager.Common.RMProfileClient($azureRmProfile)
-   $newtoken = $profileClient.AcquireAccessToken($context.Subscription.TenantID)
-
-   $armEndpoint = $context.Environment.ResourceManagerUrl
-   $applicationRegistrationParams = @{
-       Method  = [Microsoft.PowerShell.Commands.WebRequestMethod]::Get
-       Headers = @{ Authorization = "Bearer " + $newtoken.AccessToken }
-       Uri = "$($armEndpoint.ToString().TrimEnd('/'))/applicationRegistrations?api-version=2014-04-01-preview"
-   }
-
-   $applicationRegistrations = Invoke-RestMethod @applicationRegistrationParams | Select-Object -ExpandProperty value
-   "[{0}] App Registrations were found for {1}" -f $applicationRegistrations.appId.Count, $context.Environment.Name | Write-Host -ForegroundColor Green
-   $applicationRegistrations.appId | Write-Host
-   ```
-
 1. Remove Azure Stack Hub registration and prevent usage data being pushed to Azure billing.
 
    1. Follow the steps from [Register Azure Stack Hub](azure-stack-registration.md?pivots=state-connected#renew-or-change-registration) to import the **RegisterWithAzure.psm1** module.
@@ -70,10 +40,40 @@ Follow these steps in a connected (Azure AD) environment:
    Remove-AzsRegistration -PrivilegedEndpointCredential $YourCloudAdminCredential -PrivilegedEndpoint $YourPrivilegedEndpoint -RegistrationName '<Registration name from portal>' -ResourceGroupName '<Registration resource group from portal>'
    ```
 
-1. Work with your Azure AD administrator to remove the app registrations in the previously generated list.
+1. Remove Azure AD app registrations for Azure Stack Hub:
+   1. [Connect to your Azure Stack environment with Azure PowerShell](azure-stack-powershell-configure-admin.md#connect-with-azure-ad).
+   1. In the same PowerShell instance as the previous step, run the following script to export a list of all app registration IDs.
 
-   > [!NOTE]
-   > Proceed with app registration cleanup with caution. Outside of the Privileged Endpoint (PEP), your Azure Stack Hub system becomes unusable once these are removed. The app registrations cannot be restored, and your system will not function without being redeployed.
+       ```powershell
+       $context = Get-AzContext
+       if (!$context.Subscription){
+       @"
+       # Connect To Azure Stack Admin Azure Resource Manager endpoint first https://learn.microsoft.com/azure-stack/operator/azure-stack-powershell-configure-admin#connect-with-azure-ad
+       "@ | Write-Host -ForegroundColor:Red
+       }
+    
+       "Getting access token for tenant {0}" -f $context.Subscription.TenantID | Write-Host -ForegroundColor Green
+    
+       $azureRmProfile = [Microsoft.Azure.Commands.Common.Authentication.Abstractions.AzureRmProfileProvider]::Instance.Profile
+       $profileClient = New-Object Microsoft.Azure.Commands.ResourceManager.Common.RMProfileClient($azureRmProfile)
+       $newtoken = $profileClient.AcquireAccessToken($context.Subscription.TenantID)
+    
+       $armEndpoint = $context.Environment.ResourceManagerUrl
+       $applicationRegistrationParams = @{
+           Method  = [Microsoft.PowerShell.Commands.WebRequestMethod]::Get
+           Headers = @{ Authorization = "Bearer " + $newtoken.AccessToken }
+           Uri = "$($armEndpoint.ToString().TrimEnd('/'))/applicationRegistrations?api-version=2014-04-01-preview"
+       }
+    
+       $applicationRegistrations = Invoke-RestMethod @applicationRegistrationParams | Select-Object -ExpandProperty value
+       "[{0}] App Registrations were found for {1}" -f $applicationRegistrations.appId.Count, $context.Environment.Name | Write-Host -ForegroundColor Green
+       $applicationRegistrations.appId | Write-Host
+       ```
+
+   1. Work with your Azure AD administrator to remove the app registrations in the previously generated list.
+
+      > [!NOTE]
+      > Proceed with app registration cleanup with caution. Outside of the Privileged Endpoint (PEP), your Azure Stack Hub system becomes unusable once these are removed. The app registrations cannot be restored, and your system will not function without being redeployed.
 
 ## Disconnected scenarios
 


### PR DESCRIPTION
Two changes:
1. Fixed code display/formatting issue for the list AAD registrations script.
2. After some testing, we re-consolidated the list/remove AAD applications steps and put it after the Remove-AzsRegistration step.