### PR TITLE
Update work-with-horizontal-autoscaler.md

### DIFF
--- a/AKS-Hybrid/work-with-horizontal-autoscaler.md
+++ b/AKS-Hybrid/work-with-horizontal-autoscaler.md
@@ -57,7 +57,7 @@ Set-AksHciCluster -Name <string> [-enableAutoScaler <boolean>] [-autoScalerProfi
 
 ### Enable autoscaling on an existing node pool
 
-To enable autoscaling on an existed node pool, use the `autoScaler` parameter with the `Set-AksHciNodePool` command:
+To enable autoscaling on an existing node pool, use the `autoScaler` parameter with the `Set-AksHciNodePool` command:
 
 ```powershell
 Set-AksHciNodePool -clusterName <Your-Cluster-Name> -name <Your-NodePool-Name> -autoScaler $true

--- a/AKS-Hybrid/work-with-horizontal-autoscaler.md
+++ b/AKS-Hybrid/work-with-horizontal-autoscaler.md
@@ -55,6 +55,14 @@ To enable autoscaling automatically on each newly created node pool on an existi
 Set-AksHciCluster -Name <string> [-enableAutoScaler <boolean>] [-autoScalerProfileName <String>] 
 ```
 
+### Enable autoscaling on an existing node pool
+
+To enable autoscaling on an existed node pool, use the `autoScaler` parameter with the `Set-AksHciNodePool` command:
+
+```powershell
+Set-AksHciNodePool -clusterName <Your-Cluster-Name> -name <Your-NodePool-Name> -autoScaler $true
+```
+
 ## Disable autoscaling
 
 To disable autoscaling on all existing and newly created node pools on an existing cluster, set `enableAutoScaler` to false using the `Set-AksHciCluster` command:


### PR DESCRIPTION
Adding description for how to manually enable autoscaling on an existed node pool.

When users enabled autoscaling on an existing cluster, it won't enable autoscaling on existing node pools, as it only affects node pools created afterwards. **Cluster autoscaling won't work** if users decide to test the feature right away without creating new node pools. Therefore, I think we should tell users how to manually enable it.