### PR TITLE
Update deploy-arc-resource-bridge-using-command-line.md

### DIFF
--- a/azure-stack/hci/manage/deploy-arc-resource-bridge-using-command-line.md
+++ b/azure-stack/hci/manage/deploy-arc-resource-bridge-using-command-line.md
@@ -106,7 +106,7 @@ In preparation to install Azure Arc Resource Bridge on an Azure Stack HCI cluste
       > [!TIP]
       > See [Limitations and known issues](troubleshoot-arc-enabled-vms.md#limitations-and-known-issues) if Azure Kubernetes Service is also enabled to run on this cluster.
 
-1. Update the required extensions.
+1. Update the required extensions in all cluster nodes.
 
    - Uninstall the old extensions:
 


### PR DESCRIPTION
When installing in a cluster the extension should be installed in all nodes, after deployment and when the VM is moved around between the nodes the az commands will not work on the nodes that don´t have the extension and will need someone to check all nodes for the one with the extension.