### PR TITLE
Update create-virtual-networks.md

### DIFF
--- a/azure-stack/hci/manage/create-virtual-networks.md
+++ b/azure-stack/hci/manage/create-virtual-networks.md
@@ -59,10 +59,10 @@ You can use the `azurestackhci virtualnetwork` cmdlet to create a virtual networ
 
    | Parameter | Description |
    | ----- | ----------- |
-   | **name** | Name for the virtual network that you'll create for your Azure Stack HCI cluster. Make sure to provide a name that follows the [Rules for Azure resources.](/azure/cloud-adoption-framework/ready/azure-best-practices/resource-naming#example-names-networking) You can't rename a virtual network after it's created. |
-   | **vm-switch-name** |Name of the external virtual switch on your Azure Stack HCI cluster where you deploy the virtual network. |
-   | **resource-group** |Name of the resource group where you create the virtual network. For ease of management, we recommend that you use the same resource group as your Azure Stack HCI cluster. |
-   | **subscription** |Name or ID of the subscription where your Azure Stack HCI is deployed. This could be another subscription you use for virtual network on your Azure Stack HCI cluster. |
+   | **Name** | Name for the virtual network that you'll create for your Azure Stack HCI cluster. Make sure to provide a name that follows the [Rules for Azure resources.](/azure/cloud-adoption-framework/ready/azure-best-practices/resource-naming#example-names-networking) You can't rename a virtual network after it's created. |
+   | **Vm-switch-name** |Name of the external virtual switch on your Azure Stack HCI cluster where you deploy the virtual network. |
+   | **Resource-group** |Name of the resource group where you create the virtual network. For ease of management, we recommend that you use the same resource group as your Azure Stack HCI cluster. |
+   | **Subscription** |Name or ID of the subscription where your Azure Stack HCI is deployed. This could be another subscription you use for virtual network on your Azure Stack HCI cluster. |
    | **CustomLocation** |Name or ID of the custom location associated with your Azure Stack HCI cluster where you are creating this virtual network. |
    | **Location** | Azure regions as specified by `az locations`. |
 
@@ -71,7 +71,7 @@ You can use the `azurestackhci virtualnetwork` cmdlet to create a virtual networ
 
    | Parameter | Description |
    | --------- | ----------- |
-   | **IPAllocationMethod** |IP address allocation method and could be `Dynamic` or `Static`. If this parameter isn't specified, by default the virtual network is created with a dynamic configuration. |
+   | **IpAllocationMethod** |IP address allocation method and could be `Dynamic` or `Static`. If this parameter isn't specified, by default the virtual network is created with a dynamic configuration. |
    | **IpAddressPrefix** | Subnet address in CIDR notation. For example: "192.168.0.0/16".  |
 
 
@@ -81,7 +81,7 @@ You can use the `azurestackhci virtualnetwork` cmdlet to create a virtual networ
    | --------- | ----------- |
    | **DNSServers** | List of IPv4 addresses of DNS servers. Specify multiple DNS servers in a space separated format. For example: "10.0.0.5" "10.0.0.10"|
    | **Gateway** | Ipv4 address of the default gateway. |
-   | **VLan ID** | vLAN identifier for Arc VMs. Contact your network admin to get this value. A value of 0 implies that there's no vLAN ID.  |
+   | **Vlan** | vLAN identifier for Arc VMs. Contact your network admin to get this value. A value of 0 implies that there's no vLAN ID.  |
 
 ### Create a DHCP virtual network
 
@@ -90,18 +90,18 @@ Create a DHCP virtual network when the underlying network to which you want to c
 1. Set the parameters. Here's an example using the default external switch:
 
     ```azurecli
-    $VNetName = "test-vnet-dynamic"
-    $VSwitchName = "ConvergedSwitch(compute_management)"    
-    $Subscription =  "hcisub" 
-    $ResourceGroupName = "hcirg"
-    $CustomLocName = "altsnclus-cl" 
-    $Location = "eastus2euap"
+    $VnetName = "test-vnet-dynamic"
+    $VswitchName = "ConvergedSwitch(compute_management)"    
+    $subscription =  "hcisub" 
+    $resource_group = "hcirg"
+    $customloc_name = "altsnclus-cl" 
+    $location = "eastus2euap"
     ```
 
 1. Run the following cmdlet to create a DHCP virtual network:
 
    ```azurecli
-   az azurestackhci virtualnetwork create --subscription $Subscription --resource-group $ResourceGroupName --extended-location name="/subscriptions/$Subscription/resourceGroups/$ResourceGroupName/providers/Microsoft.ExtendedLocation/customLocations/$CustomLocName" type="CustomLocation" --location $Location --IpAllocationMethod "Dynamic" --network-type "Transparent" --name $VNetName --vm-switch-name $VSwitchName
+   az azurestackhci virtualnetwork create --subscription $Subscription --resource-group $resource_group --extended-location name="/subscriptions/$Subscription/resourceGroups/$resource_group/providers/Microsoft.ExtendedLocation/customLocations/$customloc_name" type="CustomLocation" --location $Location --IpAllocationMethod "Dynamic" --network-type "Transparent" --name $VNetName --vm-switch-name $VSwitchName
    ```
 
     Here's a sample output:
@@ -151,8 +151,8 @@ Create a static virtual network when you want to create virtual machines with ne
     $VNetName = "test-vnet-static"
     $VSwitchName = '"ConvergedSwitch(compute_management)"' 
     $Subscription =  "hcisub" 
-    $ResourceGroupName = "hcirg"
-    $CustomLocName = "altsnclus-cl" 
+    $resource_group = "hcirg"
+    $customloc_name = "altsnclus-cl" 
     $Location = "eastus2euap" 
     $AddressPrefix = "10.0.0.0/24"
     ```
@@ -163,7 +163,7 @@ Create a static virtual network when you want to create virtual machines with ne
 1. Create a static virtual network. Run the following cmdlet:
  
     ```azurecli
-    az azurestackhci virtualnetwork create --subscription $subscription --resource-group $resource_group --extended-location name=$customLocationID type="CustomLocation" --location $Location --network-type "Transparent" --name $VNetName --vm-switch-name $VSwitchName --ip-allocation-method "Static" --address-prefix $AddressPrefix   
+    az azurestackhci virtualnetwork create --subscription $subscription --resource-group $resource_group --extended-location name="/subscriptions/$Subscription/resourceGroups/$resource_group/providers/Microsoft.ExtendedLocation/customLocations/$customloc_name" type="CustomLocation" --location $Location --network-type "Transparent" --name $VNetName --vm-switch-name $VSwitchName --ip-allocation-method "Static" --address-prefix $AddressPrefix   
     ```
     Here's a sample output:
 


### PR DESCRIPTION
- Changed parameter names to match with https://learn.microsoft.com/en-us/azure-stack/hci/manage/manage-virtual-machines-in-azure-portal which is more convenient when deploying the RB first and then creating a network.

- Changed upper/lowercase to match other documentation.

- Corrected "VLAN ID" to "Vlan" as that is the correct parameter. See https://learn.microsoft.com/en-us/cli/azure/azurestackhci/virtualnetwork?view=azure-cli-latest#az-azurestackhci-virtualnetwork-create

- Replaced "$customLocationID" as this was a non-existent parameter in the documentation and used the full path of the location