### PR TITLE
Update multiple-load-balancers.md

### DIFF
--- a/AKS-Hybrid/multiple-load-balancers.md
+++ b/AKS-Hybrid/multiple-load-balancers.md
@@ -39,7 +39,7 @@ To deploy multiple load balancers during the workload cluster creation, use the 
    $lbcfg = New-AksHciLoadBalancerSetting -name "haProxyLB" -loadBalancerSku HAProxy -vmSize Standard_K8S3_v1 -loadBalancerCount 3
    ```
 
-1. Deploy a workload cluster without providing the load balancer configuration using the following command:
+1. Deploy a workload cluster by providing the load balancer configuration using the following command:
 
    ```powershell
    New-AksHciCluster -name "holidays" -nodePoolName "thanksgiving" -nodeCount 2 -OSType linux -nodeVmSize Standard_A4_v2 -loadBalancerSettings $lbCfg


### PR DESCRIPTION
Point 2 should read "deploy a workload cluster by providing the load balancer configuration (...)" and not "without providing .."

I believe this is a typo caused by copying the string from this other article for a custom LB

https://learn.microsoft.com/en-us/azure/aks/hybrid/configure-custom-load-balancer