### PR TITLE
Update aks-edge-howto-setup-nested-environment.md

### DIFF
--- a/AKS-Hybrid/aks-edge-howto-setup-nested-environment.md
+++ b/AKS-Hybrid/aks-edge-howto-setup-nested-environment.md
@@ -78,7 +78,7 @@ The previous diagram shows the different virtual machines and components of this
 
    ```powershell
    $ifIndex = (Get-NetAdapter -Name "vEthernet (AKS-Int)").ifIndex
-   New-NetIPAddress –IPAddress "172.20.1.2" -DefaultGateway "172.20.1.1" -PrefixLength "24" -InterfaceIndex $ifIndex
+   New-NetIPAddress –IPAddress "172.20.1.1" -PrefixLength "24" -InterfaceIndex $ifIndex
    ```
 
 1. Create a NAT table for connecting the internal virtual switch and the internal network connected devices with the external/Internet network:


### PR DESCRIPTION
Fix command to assign IP address to Nat vSwitch. Previous version assigned an incorrect IP and default gateway, in effect, not creating the gateway.