### PR TITLE
Update azure-benefits.md

### DIFF
--- a/azure-stack/hci/manage/azure-benefits.md
+++ b/azure-stack/hci/manage/azure-benefits.md
@@ -76,7 +76,7 @@ Before you begin, you'll need the following prerequisites:
 You can enable Azure Benefits on Azure Stack HCI using Windows Admin Center, PowerShell, Azure CLI, or Azure portal. The following sections describe each option.
 
 > [!NOTE]
-> To successfully enable Azure Benefits on Gen1 VMs, the VM must first be powered off to allow for the NIC to be added.
+> To successfully enable Azure Benefits on Generation 1 VMs, the VM must first be powered off to allow for the NIC to be added.
 
 ## Manage Azure Benefits
 

--- a/azure-stack/hci/manage/azure-benefits.md
+++ b/azure-stack/hci/manage/azure-benefits.md
@@ -76,7 +76,7 @@ Before you begin, you'll need the following prerequisites:
 You can enable Azure Benefits on Azure Stack HCI using Windows Admin Center, PowerShell, Azure CLI, or Azure portal. The following sections describe each option.
 
 > [!NOTE]
-> To successfully enable Azure Benefits on Generation 1 VMs, the VM must first be powered off to allow for the NIC to be added.
+> To successfully enable Azure Benefits on Generation 1 VMs, the VM must first be powered off to enable the NIC to be added.
 
 ## Manage Azure Benefits
 

--- a/azure-stack/hci/manage/azure-benefits.md
+++ b/azure-stack/hci/manage/azure-benefits.md
@@ -75,6 +75,9 @@ Before you begin, you'll need the following prerequisites:
 
 You can enable Azure Benefits on Azure Stack HCI using Windows Admin Center, PowerShell, Azure CLI, or Azure portal. The following sections describe each option.
 
+> [!NOTE]
+> To successfully enable Azure Benefits on Gen1 VMs, the VM must first be powered off to allow for the NIC to be added.
+
 ## Manage Azure Benefits
 
 ## [Windows Admin Center](#tab/wac)


### PR DESCRIPTION
Requesting to add a note regarding a limitation of enabling Azure Benefits on Gen1 VMs.  Because these VMs do not allow hot-adding hardware, these VMs must be powered off prior to enabling attestation so the addition of the IMDS NIC will succeed.