### PR TITLE
Update uninstall-arc-resource-bridge.md

### DIFF
--- a/azure-stack/hci/manage/uninstall-arc-resource-bridge.md
+++ b/azure-stack/hci/manage/uninstall-arc-resource-bridge.md
@@ -49,7 +49,7 @@ Follow these steps to uninstall Azure Arc VM management:
 4. Remove the Kubernetes extension:
 
    ```azurecli
-   az k8s-extension delete --cluster-type appliances --cluster-name $resource_name --resource-group $resource_group --name vmss-hci --yes
+   az k8s-extension delete --cluster-type appliances --cluster-name $resource_name --resource-group $resource_group --name hci-vmoperator --yes
    ```
 
 5. Remove the appliance:


### PR DESCRIPTION
Updated the Delete command for Kubernetes extension, the name presented was when ARCRB was installed over Windows Admin Center that is not possible anymore.