### PR TITLE
Fix affinity rule scenario example in vm-affinity.md

### DIFF
--- a/azure-stack/hci/manage/vm-affinity.md
+++ b/azure-stack/hci/manage/vm-affinity.md
@@ -206,7 +206,7 @@ WebData     SameFaultDomain   {SQL1, WEB1}     1
 
 ### Scenario 2
 
-Let's use the same scenario above except specify that the VMs must reside on the same cluster node but not necessarily in the same site. Using `SameNode`, you can set this as follows:
+Let's use the same scenario above except specify that the VMs must reside on the same cluster node. Using `SameNode`, you can set this as follows:
 
 ```powershell
 New-ClusterAffinityRule -Name WebData1 -Ruletype SameNode -Cluster Cluster1


### PR DESCRIPTION
Fixing description of affinity rule scenario 2 - if we are setting affinity to keep two VMs on the same node, they necessarily are in the same site.