### PR TITLE
removed accidental path description

### DIFF
--- a/AKS-Hybrid/aks-edge-howto-use-storage-local-path.md
+++ b/AKS-Hybrid/aks-edge-howto-use-storage-local-path.md
@@ -105,7 +105,7 @@ kubectl apply -f https://raw.githubusercontent.com/Azure/AKS-Edge/main/samples/s
 Finally, read the content of the file that was previously written. If everything runs successfully, you should see the **Hello AKS Edge!** message.
 
 ```output
-PS C:\WINDOWS\system32> kubectl exec volume-test -- sh -c "cat /data/test"
+kubectl exec volume-test -- sh -c "cat /data/test"
 Hello AKS Edge!
 ```
 


### PR DESCRIPTION
That path in 
```
PS C:\WINDOWS\system32> kubectl ....
```
is deleted.

Is should be like:
```
kubectl ....
```
Now it's on par with the other code samples