### PR TITLE
Powershell string variables need quotation

### DIFF
--- a/AKS-Hybrid/system-requirements.md
+++ b/AKS-Hybrid/system-requirements.md
@@ -259,8 +259,8 @@ Run the following steps to create a new service principal with the built-in **Ow
 
 Set the following PowerShell variables in a PowerShell admin window. Verify that the subscription and tenant are what you want to use to register your AKS host for billing.
 ```powershell
-$subscriptionID = <Your Azure subscrption ID>
-$tenantID = <Your Azure tenant ID>
+$subscriptionID = "<Your Azure subscrption ID>"
+$tenantID = "<Your Azure tenant ID>"
 ```
 
 Install and import the AKS hybrid PowerShell module:


### PR DESCRIPTION
Both Powershell variables are written without double-quotes.

This will result in an error like

```
XYZ: The term 'XYZ' is not recognized as the name of a cmdlet, function, script file, or operable program.
Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
At line:1 char:19
+ $subscriptionID = XYZ
+                   ~~~~~~~
    + CategoryInfo          : ObjectNotFound: (XYZ:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException
```

This is not fixed.