### PR TITLE
Update deployment-prep-active-directory.md

### DIFF
--- a/azure-stack/hci/deploy/deployment-prep-active-directory.md
+++ b/azure-stack/hci/deploy/deployment-prep-active-directory.md
@@ -23,6 +23,15 @@ Before you begin, make sure you've done the following:
 
 - Satisfy the [prerequisites](./deployment-prerequisites.md) for new deployments of Azure Stack HCI.
 - Complete the [deployment checklist](./deployment-checklist.md).
+- Install Remote Server Administration tools :
+    - Active Directory Services and Lightweight Directory Services
+      ```powershell
+      Enable-WindowsOptionalFeature -Online -FeatureName "RSAT-AD-Tools-Feature"
+      ```
+    - DNS Server Tools
+      ```powershell
+      Enable-WindowsOptionalFeature -Online -FeatureName "DNS-Server-Tools"
+      ```
 - Install the PowerShell module to prepare Active Directory. You can follow one of these options:
     - [Download AsHciADArtifactsPreCreationTool.psm1 from this location](https://github.com/Azure/AzureStack-Tools/tree/master/HCI). Run the following command:
     


### PR DESCRIPTION
the AD tools AsHciADArtifactsPreCreationTool requires both AD  and DNS tools to run on a jump box, otherwise the customer receive an error