### PR TITLE
Update aks-networks.md

### DIFF
--- a/AKS-Hybrid/aks-networks.md
+++ b/AKS-Hybrid/aks-networks.md
@@ -71,7 +71,7 @@ New-ArcHciVirtualNetwork -name $clustervnetname -vswitchname $vswitchname -vippo
 
 | Parameter    | Description | DHCP | Static |
 |------------------|---------|-----------|-------------------|
-| `$clustervnetname` | The name of your virtual network for AKS hybrid clusters. (Please note the name must be lowercase) | ![Supported](media/aks-hybrid-networks/check.png) | ![Supported](media/aks-hybrid-networks/check.png) |
+| `$clustervnetname` | The name of your virtual network for AKS hybrid clusters. This name must be lowercase. | ![Supported](media/aks-hybrid-networks/check.png) | ![Supported](media/aks-hybrid-networks/check.png) |
 | `$vswitchname`     | The name of your VM switch. | ![Supported](media/aks-hybrid-networks/check.png) | ![Supported](media/aks-hybrid-networks/check.png) |
 | `$ipaddressprefix` | The IP address value of your subnet.  | N/A | ![Supported](media/aks-hybrid-networks/check.png) |
 | `$gateway`         | The IP address value of your gateway for the subnet.  | N/A | ![Supported](media/aks-hybrid-networks/check.png) |

--- a/AKS-Hybrid/aks-networks.md
+++ b/AKS-Hybrid/aks-networks.md
@@ -71,7 +71,7 @@ New-ArcHciVirtualNetwork -name $clustervnetname -vswitchname $vswitchname -vippo
 
 | Parameter    | Description | DHCP | Static |
 |------------------|---------|-----------|-------------------|
-| `$clustervnetname` | The name of your virtual network for AKS hybrid clusters. | ![Supported](media/aks-hybrid-networks/check.png) | ![Supported](media/aks-hybrid-networks/check.png) |
+| `$clustervnetname` | The name of your virtual network for AKS hybrid clusters. (Please note the name must be lowercase) | ![Supported](media/aks-hybrid-networks/check.png) | ![Supported](media/aks-hybrid-networks/check.png) |
 | `$vswitchname`     | The name of your VM switch. | ![Supported](media/aks-hybrid-networks/check.png) | ![Supported](media/aks-hybrid-networks/check.png) |
 | `$ipaddressprefix` | The IP address value of your subnet.  | N/A | ![Supported](media/aks-hybrid-networks/check.png) |
 | `$gateway`         | The IP address value of your gateway for the subnet.  | N/A | ![Supported](media/aks-hybrid-networks/check.png) |


### PR DESCRIPTION
There is a known issue if the AKS VNET name contains UPPERCASE characters. Adding in a note to prevent this from happening to customers, suggesting the name be in all LOWERCASE, until ARM can handle.