### PR TITLE
Update system-requirements.md

### DIFF
--- a/AKS-Hybrid/system-requirements.md
+++ b/AKS-Hybrid/system-requirements.md
@@ -135,7 +135,7 @@ When creating a Kubernetes cluster on Azure Stack HCI, the following firewall po
 
 If the Azure Stack HCI physical cluster nodes and the Azure Kubernetes cluster VMs are on two isolated vlans, these ports must be opened at the firewall between them:
 
-| Port   | Source                               | Description                                        | Firewall Notes                                                                               |
+| Port   | Destination                          | Description                                        | Firewall Notes                                                                               |
 |-------|--------------------------------------|----------------------------------------------------|----------------------------------------------------------------------------------------------|
 | 22    | AKS VMs                              | Required to collect logs when using `Get-AksHciLogs`. | If using separate VLANs, the physical Hyper-V Hosts must access the AKS VMs on this port. |
 | 6443  | AKS VMs                              | Required to communicate with Kubernetes APIs.       | If using separate VLANs, the physical Hyper-V Hosts must access the AKS VMs on this port. |


### PR DESCRIPTION
@abhilashaagarwala - I think the header should be called destination here. By configuring our FW again for new clusters and reading the description -> sources is here destination in the FW rules.