### PR TITLE
Change 2405 to be a Baseline update

### DIFF
--- a/azure-stack/hci/release-information-23h2.md
+++ b/azure-stack/hci/release-information-23h2.md
@@ -55,7 +55,7 @@ All dates are listed in ISO 8601 format: *YYYY-MM-DD*
 
 |Release build| OS build |Baseline or Update| What's new | Known issues |
 |--|--|--|--|--|
-| 10.2405.0.23 | 25398.887  <br><br> [May OS security update](./security-update/hci-security-update-may-2024.md) <br><br> Availability date: 2024-05-30 | Update | [Features and improvements](./whats-new.md#features-and-improvements-in-2405) | [Known issues](./known-issues-2405.md) |
+| 10.2405.0.23 | 25398.887  <br><br> [May OS security update](./security-update/hci-security-update-may-2024.md) <br><br> Availability date: 2024-05-30 | Baseline | [Features and improvements](./whats-new.md#features-and-improvements-in-2405) | [Known issues](./known-issues-2405.md) |
 | 10.2402.3.10 | 25398.887  <br><br> [May OS security update](./security-update/hci-security-update-may-2024.md) <br><br> Availability date: 2024-05-21 | Update | [Features and improvements](./whats-new.md#features-and-improvements-in-24023) | [Known issues](./known-issues-2402-3.md) |
 | 10.2402.2.12 | 25398.830  <br><br> [April OS security update](./security-update/hci-security-update-apr-2024.md) <br><br> Availability date: 2024-04-16 | Update | [Features and improvements](./whats-new.md#features-and-improvements-in-24022) | [Known issues](./known-issues-2402-2.md) |
 | 10.2311.5.6 | 25398.830  <br><br> [April OS security update](./security-update/hci-security-update-apr-2024.md) <br><br> Availability date: 2024-04-16 | Update | [Features and improvements](./whats-new.md#features-and-improvements-in-23115) | [Known issues](./known-issues-2311-5.md) |


### PR DESCRIPTION
As per 
![image](https://github.com/MicrosoftDocs/azure-stack-docs/assets/28607803/633b246a-bcc1-40e9-8e89-9918904481d1)

2405 is a Baseline release, not an Update release.