### PR TITLE
updated 'deploy-gpu-node-pool.md' with instructions for using Headless OS

### DIFF
--- a/AKS-Hybrid/deploy-gpu-node-pool.md
+++ b/AKS-Hybrid/deploy-gpu-node-pool.md
@@ -62,19 +62,19 @@ Install the Azure Stack HCI, version 23H2 operating system locally on each serve
 
 ### Step 2: uninstall the NVIDIA host driver
 
-Open a remote powershell session to each host, or run the following local in Powershell.You will need to start by uninstalling the NVIDIA host driver, then reboot the machine. After the machine reboots, confirm that the driver was successfully uninstalled.
+Open a remote powershell session to each host, or run the following local in Powershell. Start by uninstalling the NVIDIA host driver, then reboot the machine. After the machine reboots, confirm that the driver was successfully uninstalled:
 
 ```powershell
 PNPUTIL /enum-drivers
 ```
 
-
- Open an elevated PowerShell terminal and run the following command:
+Open an elevated PowerShell prompt and run the following command:
 
 ```powershell
 Get-PnpDevice  | select status, class, friendlyname, instanceid | findstr /i /c:"3d video" 
 ```
-You should see the Installed Drivers in the PNPUTIL output, if the "Provider Name" is listed as "NVIDIA Corporation" that is the driver you need to target for uninstall, note the "Published Name" you will be using that in the next command.
+
+You should see the installed drivers in the **PNPUTIL** output. If the **Provider Name** is listed as **NVIDIA Corporation**, that is the driver you need to target for uninstalling. Make a note of the **Published Name**, as you must use that in the next command:
 
 ```output
 Published Name:     oem15.inf
@@ -86,12 +86,12 @@ Driver Version:     03/05/2024 31.0.15.5178
 Signer Name:        Microsoft Windows Hardware Compatibility Publisher
 ```
 
-Run the following in your Powershell session, replacing the ".\oem1.inf" with the value in "Published  Name" from the "PNPUTIL Enum-Devices" output from earlier.
+Run the following command in your Powershell session, and replace `.\oem1.inf` with the value in **Published Name** from the previous **PNPUTIL Enum-Devices** output.
 
 ```powershell
 pnputil /delete-driver .\oem1.inf /uninstall /reboot
 ```
-After the reboot is complete, reconnect via Powershell or RDP Session. 
+After the reboot is complete, reconnect via Powershell or an RDP Session. 
 
 You should see the GPU devices appear in an error state as shown in this example output:
 

--- a/AKS-Hybrid/deploy-gpu-node-pool.md
+++ b/AKS-Hybrid/deploy-gpu-node-pool.md
@@ -86,7 +86,7 @@ Driver Version:     03/05/2024 31.0.15.5178
 Signer Name:        Microsoft Windows Hardware Compatibility Publisher
 ```
 
-Run the following command in your Powershell session, and replace `.\oem1.inf` with the value in **Published Name** from the previous **PNPUTIL Enum-Devices** output.
+Run the following command in your Powershell session, and replace `.\oem1.inf` with the value in **Published Name** from the previous **PNPUTIL Enum-Devices** output:
 
 ```powershell
 pnputil /delete-driver .\oem1.inf /uninstall /reboot

--- a/AKS-Hybrid/deploy-gpu-node-pool.md
+++ b/AKS-Hybrid/deploy-gpu-node-pool.md
@@ -107,7 +107,7 @@ When you uninstall the host driver, the physical GPU goes into an error state. Y
 For each GPU (3D Video Controller) device, run the following commands in PowerShell. Copy the instance ID; for example, `PCI\VEN_10DE&DEV_1EB8&SUBSYS_12A210DE&REV_A1\4&32EEF88F&0&0000` from the previous command output:
 
 ```powershell
-$gpu=Get-PnpDevice  -FriendlyName "3D Video Controller"
+$gpu=Get-PnpDevice -FriendlyName "3D Video Controller"
 $id1 =$gpu[0].InstanceId
 $lp1 = (Get-PnpDeviceProperty -KeyName DEVPKEY_Device_LocationPaths -InstanceId $id1).Data[0]
 Disable-PnpDevice -InstanceId $id1 -Confirm:$false

--- a/AKS-Hybrid/deploy-gpu-node-pool.md
+++ b/AKS-Hybrid/deploy-gpu-node-pool.md
@@ -113,9 +113,9 @@ For each GPU (3D Video Controller) device, run the following commands in PowerSh
 ```powershell
 $gpu=Get-PnpDevice -FriendlyName "3D Video Controller"
 $id0 =$gpu[0].InstanceId
-$lp0 = (Get-PnpDeviceProperty -KeyName DEVPKEY_Device_LocationPaths -InstanceId $id1).Data[0]
-Disable-PnpDevice -InstanceId $id1 -Confirm:$false
-Dismount-VMHostAssignableDevice -LocationPath $lp1 -Force
+$lp0 = (Get-PnpDeviceProperty -KeyName DEVPKEY_Device_LocationPaths -InstanceId $id0).Data[0]
+Disable-PnpDevice -InstanceId $id0 -Confirm:$false
+Dismount-VMHostAssignableDevice -LocationPath $lp0 -Force
 ```
 
 If you have more than one GPU, use the following additional command:

--- a/AKS-Hybrid/deploy-gpu-node-pool.md
+++ b/AKS-Hybrid/deploy-gpu-node-pool.md
@@ -114,7 +114,7 @@ Disable-PnpDevice -InstanceId $id1 -Confirm:$false
 Dismount-VMHostAssignableDevice -LocationPath $lp1 -Force
 ```
 
-IF you have more then one GPU, please use the additonal command:
+If you have more than one GPU, use the following additional command:
 
 ```powershell
 $gpu=Get-PnpDevice -FriendlyName "3D Video Controller"

--- a/AKS-Hybrid/deploy-gpu-node-pool.md
+++ b/AKS-Hybrid/deploy-gpu-node-pool.md
@@ -93,6 +93,10 @@ pnputil /delete-driver .\oem1.inf /uninstall /reboot
 ```
 After the reboot is complete, reconnect via Powershell or an RDP Session. 
 
+```powershell
+Get-PnpDevice | Where-Object FriendlyName -Like '3D Video*' | Select-Object Status, FriendlyName, InstanceId 
+```
+
 You should see the GPU devices appear in an error state as shown in this example output:
 
 ```output


### PR DESCRIPTION
The instructions for uninstalling drivers was written for a Desktop Experience Server, not Azure Stack HCI, which is intended OS, I updated docs to include PowerShell examples. 