### PR TITLE
updated requirements, warnings and errors

### DIFF
--- a/azure-stack/hci/deploy/deployment-arc-register-server-permissions.md
+++ b/azure-stack/hci/deploy/deployment-arc-register-server-permissions.md
@@ -134,8 +134,8 @@ Before you begin, make sure you've completed the following prerequisites:
 
 > [!IMPORTANT]
 > Ensure that the account you are using for device login has the required permissions on the subscription.
-> The account might not be of type "MicrosoftAccount" but must be a native Entra AD >account. Otherwise Get-AzSubscription will fail with error "AADSTS9002332: AppID 
->(Application Windows Azure Service Management API) is configured for use by Azure >Active Directory users only. Please do not use the /consumers endpoint to serve this >request." Where Azure Active Directory translates into the new name Entra AD.
+> The account might not be of type "MicrosoftAccount" but must be a native Entra AD account. Otherwise Get-AzSubscription will fail with error "AADSTS9002332: AppID 
+>(Application Windows Azure Service Management API) is configured for use by Azure Active Directory users only. Please do not use the /consumers endpoint to serve this request." Where Azure Active Directory translates into the new name Entra AD.
 
 1. Connect to your Azure account and set the subscription. You'll need to open browser on the client that you're using to connect to the server and open this page: `https://microsoft.com/devicelogin` and enter the provided code in the Azure CLI output to authenticate. Get the access token and account ID for the registration.  
 

--- a/azure-stack/hci/deploy/deployment-arc-register-server-permissions.md
+++ b/azure-stack/hci/deploy/deployment-arc-register-server-permissions.md
@@ -51,7 +51,7 @@ Before you begin, make sure you've completed the following prerequisites:
 
 > [!IMPORTANT]
 > Run these steps on every Azure Stack HCI server that you intend to cluster.
-> Do not use the Install-Module -Force as this would forcibly install the latest version of dependend modules, overwriting older ones. For example: Install-Module Az.Ressources -Force would update Az.Accounts to a later version than required 2.13.2, causing AzStackHciArcInitialization to fail.
+> Do not use the Install-Module -Force as this would forcibly install the latest version of dependend modules, overwriting older ones. For example: Install-Module Az.Ressources -Force would update Az.Accounts to a later version than required 2.13.2, causing Invoke-AzStackHciArcInitialization to fail.
 
 1. Install the [Arc registration script](https://www.powershellgallery.com/packages/AzSHCI.ARCInstaller) from PSGallery.
 

--- a/azure-stack/hci/deploy/deployment-arc-register-server-permissions.md
+++ b/azure-stack/hci/deploy/deployment-arc-register-server-permissions.md
@@ -51,6 +51,7 @@ Before you begin, make sure you've completed the following prerequisites:
 
 > [!IMPORTANT]
 > Run these steps on every Azure Stack HCI server that you intend to cluster.
+> Do not use the Install-Module -Force as this would forcibly install the latest version of dependend modules, overwriting older ones. For example: Install-Module Az.Ressources -Force would update Az.Accounts to a later version than required 2.13.2, causing AzStackHciArcInitialization to fail.
 
 1. Install the [Arc registration script](https://www.powershellgallery.com/packages/AzSHCI.ARCInstaller) from PSGallery.
 
@@ -130,6 +131,12 @@ Before you begin, make sure you've completed the following prerequisites:
     ```
 
     ---
+
+> [!IMPORTANT]
+> Ensure that the account you are using for device login has the required permissions on the subscription.
+> The account might not be of type "MicrosoftAccount" but must be a native Entra AD >account. Otherwise Get-AzSubscription will fail with error "AADSTS9002332: AppID 
+>(Application Windows Azure Service Management API) is configured for use by Azure >Active Directory users only. Please do not use the /consumers endpoint to serve this >request." Where Azure Active Directory translates into the new name Entra AD.
+
 1. Connect to your Azure account and set the subscription. You'll need to open browser on the client that you're using to connect to the server and open this page: `https://microsoft.com/devicelogin` and enter the provided code in the Azure CLI output to authenticate. Get the access token and account ID for the registration.  
 
     # [PowerShell](#tab/powershell)


### PR DESCRIPTION
- user may not use -force when installing modules
- user may not use MSA in Azure (this could be the first user that created the Azure tenant, but must use an Entra AD account.