### PR TITLE
Add note about not using apt/dnf searches to AMLFS Client install docs

### DIFF
--- a/azure-managed-lustre/includes/client-install-version-rhel-7.md
+++ b/azure-managed-lustre/includes/client-install-version-rhel-7.md
@@ -14,6 +14,8 @@ sudo yum install amlfs-lustre-client-2.15.4_42_gd6d405d-$(uname -r | sed -e "s/\
 
 > [!NOTE]
 > The metapackage version does not always align with the kernel version. Use the install command above to install the proper metapackage.
+> [!NOTE]
+> Running a `yum search amlfs-lustre-client` does not show all available packages for your distro. To see all available `amlfs-lustre-client` packages, please run `yum list --showduplicates "amlfs-lustre-client*"`.
 
 If you want to upgrade *only* the kernel and not all packages, you must, at minimum, also upgrade the **amlfs-lustre-client** metapackage in order for the Lustre client to continue to work after the reboot. The command should look similar to the following example:
 

--- a/azure-managed-lustre/includes/client-install-version-rhel-7.md
+++ b/azure-managed-lustre/includes/client-install-version-rhel-7.md
@@ -14,8 +14,9 @@ sudo yum install amlfs-lustre-client-2.15.4_42_gd6d405d-$(uname -r | sed -e "s/\
 
 > [!NOTE]
 > The metapackage version does not always align with the kernel version. Use the install command above to install the proper metapackage.
+
 > [!NOTE]
-> Running a `yum search amlfs-lustre-client` does not show all available packages for your distro. To see all available `amlfs-lustre-client` packages, please run `yum list --showduplicates "amlfs-lustre-client*"`.
+> Running a `yum search amlfs-lustre-client` doesn't show all available packages for your distro. To see all available `amlfs-lustre-client` packages, run `yum list --showduplicates "amlfs-lustre-client*"`.
 
 If you want to upgrade *only* the kernel and not all packages, you must, at minimum, also upgrade the **amlfs-lustre-client** metapackage in order for the Lustre client to continue to work after the reboot. The command should look similar to the following example:
 

--- a/azure-managed-lustre/includes/client-install-version-rhel-8-9.md
+++ b/azure-managed-lustre/includes/client-install-version-rhel-8-9.md
@@ -14,6 +14,8 @@ sudo dnf install amlfs-lustre-client-2.15.4_42_gd6d405d-$(uname -r | sed -e "s/\
 
 > [!NOTE]
 > The metapackage version does not always align with the kernel version. Use the install command above to install the proper metapackage.
+> [!NOTE]
+> Running a `dnf search amlfs-lustre-client` does not show all available packages for your distro. To see all available `amlfs-lustre-client` packages, please run `dnf list --showduplicates "amlfs-lustre-client*"`.
 
 If you want to upgrade *only* the kernel and not all packages, you must, at minimum, also upgrade the **amlfs-lustre-client** metapackage in order for the Lustre client to continue to work after the reboot. The command should look similar to the following example:
 

--- a/azure-managed-lustre/includes/client-install-version-rhel-8-9.md
+++ b/azure-managed-lustre/includes/client-install-version-rhel-8-9.md
@@ -14,8 +14,9 @@ sudo dnf install amlfs-lustre-client-2.15.4_42_gd6d405d-$(uname -r | sed -e "s/\
 
 > [!NOTE]
 > The metapackage version does not always align with the kernel version. Use the install command above to install the proper metapackage.
+
 > [!NOTE]
-> Running a `dnf search amlfs-lustre-client` does not show all available packages for your distro. To see all available `amlfs-lustre-client` packages, please run `dnf list --showduplicates "amlfs-lustre-client*"`.
+> Running a `dnf search amlfs-lustre-client` doesn't show all available packages for your distro. To see all available `amlfs-lustre-client` packages, run `dnf list --showduplicates "amlfs-lustre-client*"`.
 
 If you want to upgrade *only* the kernel and not all packages, you must, at minimum, also upgrade the **amlfs-lustre-client** metapackage in order for the Lustre client to continue to work after the reboot. The command should look similar to the following example:
 

--- a/azure-managed-lustre/includes/client-install-version-ubuntu.md
+++ b/azure-managed-lustre/includes/client-install-version-ubuntu.md
@@ -14,6 +14,8 @@ sudo apt install amlfs-lustre-client-2.15.4-42-gd6d405d=$(uname -r)
 
 > [!NOTE]
 > This command installs a metapackage that will keep the version of Lustre aligned with the installed kernel. In order for this to work, you must use `apt full-upgrade` instead of simply `apt upgrade` when updating your system.
+> [!NOTE]
+> Running a `apt search amlfs-lustre-client` does not show all available packages for your distro. To see all available `amlfs-lustre-client` packages, please run `apt list -a "amlfs-lustre-client*"`.
 
 Optionally, if you want to upgrade *only* the kernel (and not all packages), you must, at minimum, also upgrade the **amlfs-lustre-client** metapackage in order for the Lustre client to continue to work after the reboot. The command should look similar to the following example:
 

--- a/azure-managed-lustre/includes/client-install-version-ubuntu.md
+++ b/azure-managed-lustre/includes/client-install-version-ubuntu.md
@@ -14,8 +14,9 @@ sudo apt install amlfs-lustre-client-2.15.4-42-gd6d405d=$(uname -r)
 
 > [!NOTE]
 > This command installs a metapackage that will keep the version of Lustre aligned with the installed kernel. In order for this to work, you must use `apt full-upgrade` instead of simply `apt upgrade` when updating your system.
+
 > [!NOTE]
-> Running a `apt search amlfs-lustre-client` does not show all available packages for your distro. To see all available `amlfs-lustre-client` packages, please run `apt list -a "amlfs-lustre-client*"`.
+> Running an `apt search amlfs-lustre-client` doesn't show all available packages for your distro. To see all available `amlfs-lustre-client` packages, run `apt list -a "amlfs-lustre-client*"`.
 
 Optionally, if you want to upgrade *only* the kernel (and not all packages), you must, at minimum, also upgrade the **amlfs-lustre-client** metapackage in order for the Lustre client to continue to work after the reboot. The command should look similar to the following example:
 


### PR DESCRIPTION
Adding a note clarifying that doing an `apt/dnf search` will not work.

Ideally* it'll add another note box below this with the new text
![image](https://github.com/user-attachments/assets/9ab36842-13ce-4c7c-81a5-96910b680aa4)

If someone from the docs team could add a screenshot from the staging environment confirming the behavior that would be great!