### PR TITLE
Add missing permission for custom role

### DIFF
--- a/AKS-Hybrid/backup-workload-cluster.md
+++ b/AKS-Hybrid/backup-workload-cluster.md
@@ -167,7 +167,8 @@ The procedures in this section describe how to install Velero and use Azure Blob
                  "Microsoft.Compute/snapshots/write",
                  "Microsoft.Compute/snapshots/delete",
                  "Microsoft.Storage/storageAccounts/listkeys/action",
-                 "Microsoft.Storage/storageAccounts/regeneratekey/action"
+                 "Microsoft.Storage/storageAccounts/regeneratekey/action",
+                 "Microsoft.Storage/storageAccounts/read"
              ],
              "NotActions": [],
              "AssignableScopes": [


### PR DESCRIPTION
Fixes the error: The client '00000000-0000-0000-0000-000000000000' with object id '00000000-0000-0000-0000-000000000000' does not have authorization to perform action 'Microsoft.Storage/storageAccounts/read' over scope '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount' or the scope is invalid. If access was recently granted, please refresh your credentials.