### PR TITLE
Update hci-applies-to-22h2-21h2.md

### DIFF
--- a/azure-stack/includes/hci-applies-to-22h2-21h2.md
+++ b/azure-stack/includes/hci-applies-to-22h2-21h2.md
@@ -9,4 +9,4 @@ ms.reviewer: alkohli
 ms.lastreviewed: 11/02/2022
 ---
 
-> Applies to: Azure Stack HCI, versions 22H2 and 21H2
+> Applies to: Azure Stack HCI, versions 22H2 and later


### PR DESCRIPTION
21H2 is out of lifecycle and this page must cover 23H2 and later. Removed 21H2 and replaced with later.