### PR TITLE
Update suspend-resume-cluster-maintenance.md

### DIFF
--- a/azure-stack/hci/manage/suspend-resume-cluster-maintenance.md
+++ b/azure-stack/hci/manage/suspend-resume-cluster-maintenance.md
@@ -28,7 +28,7 @@ To suspend a cluster node, follow these steps:
 1. To suspend the cluster node, run this command:
 
     ```powershell
-    Suspend-clusternode -name “MachineName”
+    Suspend-clusternode -name “MachineName” -drain
     ```
 
     Here's example output:
@@ -113,7 +113,7 @@ To resume a cluster node, follow these steps:
 1. Add the node to the active Arc VM Configuration. **This step can only be done using PowerShell**.
 
     ```powershell
-    Remove-MocPhysicalNode -nodeName “MachineName”
+    New-MocPhysicalNode -nodeName “MachineName”
     ```
 
 1. Verify that your storage pool is healthy.


### PR DESCRIPTION
Change 1 - 
Suspend-ClusterNode will only move VM's if the "-drain" parameter is called. Otherwise the highlighted note mentioning the time that it takes to move VM's does not apply.

Change 2 -
Remove-MocPhysicalNode was used for both action, to remove and to add. The correct cmdlet to add is New-MocPhysicalNode