### PR TITLE
Update K8/3 installer links for missing Windows node files

### DIFF
--- a/AKS-Hybrid/aks-edge-howto-setup-machine.md
+++ b/AKS-Hybrid/aks-edge-howto-setup-machine.md
@@ -34,6 +34,7 @@ You can deploy an AKS Edge Essentials cluster on either a single machine or on m
    | K3s installer (1.28.5) | [aka.ms/aks-edge/k3s-msi-1.28](https://aka.ms/aks-edge/k3s-msi-1.28) |
    | K8s installer (1.27.6) | [aka.ms/aks-edge/k8s-msi-1.27](https://aka.ms/aks-edge/k8s-msi-1.27)  |
    | K3s installer (1.27.6) | [aka.ms/aks-edge/k3s-msi-1.27](https://aka.ms/aks-edge/k3s-msi-1.27) |
+   | Windows node files | [aka.ms/aks-edge/windows-node-zip](https://aka.ms/aks-edge/windows-node-zip) |
 
 1. In addition to the MSI, Microsoft provides samples and tools that you can download from the [AKS Edge GitHub repo](https://github.com/Azure/AKS-Edge). Navigate to the **Code** tab and click the **Download Zip** button to download the repository as a **.zip** file. Extract the GitHub **.zip** file to a local folder.
 1. Before you install, make sure you uninstall any private preview installations and reboot your system before proceeding.


### PR DESCRIPTION
Since commit 5fc481d12e481f8bc49d9be0d9af0a266dc7eaa4 the Windows node files have been missing from the documentation, making it difficult for new users to deploy Windows nodes as the links are not available elsewhere.