### PR TITLE
Update whats-new-2306-preview.md / added warning about usage of the Supplemental Package

### DIFF
--- a/azure-stack/hci/manage/whats-new-2306-preview.md
+++ b/azure-stack/hci/manage/whats-new-2306-preview.md
@@ -37,7 +37,7 @@ To learn more about the new deployment methods, see [Deployment overview](../dep
 >
 > If you deploy Azure Stack HCI 22H2 with SP, we advise you that this scenario is not supported to for going forward with Azure Stack HCI OS and solution upgrades, such as Azure Stack HCI 23H2 or later.
 >
-> In this case you will have to reinstall the cluster either with regular 22H2 methods, such as PowerShell or Windows Admin Center, or consider a reinstallation directly to the current release.
+> In this case you will have to reinstall the cluster either with regular 22H2 methods, such as PowerShell or Windows Admin Center, or consider a new deployment with the current release, directly.
 > We thank you for evaluating the Supplemental Package, as it laid the foundation for the Azure Stack HCI 23H2 cloudbased solution deployment.
 > See [Azure Stack HCI Upgrades - Supported workloads and configurations](../upgrade/about-upgrades-23h2.md).
 

--- a/azure-stack/hci/manage/whats-new-2306-preview.md
+++ b/azure-stack/hci/manage/whats-new-2306-preview.md
@@ -30,6 +30,17 @@ Azure Stack HCI, 2306 Supplemental Package is now in preview. You can deploy thi
 
 To learn more about the new deployment methods, see [Deployment overview](../deploy/deployment-tool-introduction.md).
 
+## Supportability
+
+>[!IMPORTANT]
+> The deployment of Azure Stack HCI 22H2 with the described Supplemental Package (SP) has become obsolete.
+>
+> If you deploy Azure Stack HCI 22H2 with SP, we advise you that this scenario is not supported to for going forward with Azure Stack HCI OS and solution upgrades, such as Azure Stack HCI 23H2 or later.
+>
+> In this case you will have to reinstall the cluster either with regular 22H2 methods, such as PowerShell or Windows Admin Center, or consider a reinstallation directly to the current release.
+> We thank you for evaluating the Supplemental Package, as it laid the foundation for the Azure Stack HCI 23H2 cloudbased solution deployment.
+> See [Azure Stack HCI Upgrades - Supported workloads and configurations](../upgrade/about-upgrades-23h2.md).
+
 ### What's new
 
 The following new features are available in the 2306 preview release of Supplemental Package:


### PR DESCRIPTION
Added remark that Supplemental package is not supported and also not allowed as a base to upgrade from 22H2. 
With this, the user should be made aware to avoid attempts using the supplemental package.

Despite the clear "preview" remark, the versioning 2306 - current version might indicate it is not outdated or not considered a blocker.

As of October 2024, there are use cases for new Azure Stack HCI 22H2 deployments or cluster / node re-installations. 
Such as:
- Stretched Clusters 
- customers that cannot accept the current limitations with their BCDR solutions
- clusternodes that are affected by "out-of policy" and could not be recovered otherwise.