### PR TITLE
Update AMLFS Client install instructions to new version

### DIFF
--- a/azure-managed-lustre/client-upgrade.md
+++ b/azure-managed-lustre/client-upgrade.md
@@ -46,7 +46,7 @@ Follow these steps to upgrade the Lustre client to the current version:
 1. Install the current version of the Lustre client using the following command:
 
     ```bash
-    sudo dnf install amlfs-lustre-client-2.15.4_42_gd6d405d-$(uname -r | sed -e "s/\.$(uname -p)$//" | sed -re 's/[-_]/\./g')-1
+    sudo dnf install amlfs-lustre-client-2.15.5_41_gc010524-$(uname -r | sed -e "s/\.$(uname -p)$//" | sed -re 's/[-_]/\./g')-1
     ```
 
 1. Verify that old kernel modules are removed using the following command:
@@ -86,7 +86,7 @@ Follow these steps to upgrade the Lustre client to the current version:
 1. Install the current version of the Lustre client using the following command:
 
     ```bash
-    sudo apt install amlfs-lustre-client-2.15.4-42-gd6d405d=$(uname -r)
+    sudo apt install amlfs-lustre-client-2.15.5-41-gc010524=$(uname -r)
     ```
 
 1. Verify that old kernel modules are removed using the following command:

--- a/azure-managed-lustre/connect-clients.md
+++ b/azure-managed-lustre/connect-clients.md
@@ -26,7 +26,6 @@ Client machines running Linux can access Azure Managed Lustre. The basic client 
 - **To achieve advertised performance**:
   - Clients must reside in the same Availability Zone in which the cluster resides.
   - [Enable accelerated networking](/azure/virtual-network/create-vm-accelerated-networking-cli#confirm-that-accelerated-networking-is-enabled) on all client VMs. If this option isn't enabled, then [fully enabling accelerated networking requires a stop/deallocate of each VM](/azure/virtual-network/accelerated-networking-overview#enabling-accelerated-networking-on-a-running-vm).
-- **Security type** - When selecting the security type for the VM, choose the Standard Security Type. Choosing Trusted Launch or Confidential types prevent the Lustre module from being properly installed on the client.
 
 The basic workflow is as follows:
 

--- a/azure-managed-lustre/includes/client-install-version-hpc-alma-86.md
+++ b/azure-managed-lustre/includes/client-install-version-hpc-alma-86.md
@@ -9,7 +9,7 @@ ms.lastreviewed: 02/15/2024
 ---
 
 ```bash
-sudo dnf install --disableexcludes=main --refresh amlfs-lustre-client-2.15.4_42_gd6d405d-$(uname -r | sed -e "s/\.$(uname -p)$//" | sed -re 's/[-_]/\./g')-1
+sudo dnf install --disableexcludes=main --refresh amlfs-lustre-client-2.15.5_41_gc010524-$(uname -r | sed -e "s/\.$(uname -p)$//" | sed -re 's/[-_]/\./g')-1
 ```
 
 > [!NOTE]
@@ -19,5 +19,5 @@ If you want to upgrade *only* the kernel and not all packages, you must, at mini
 
 ```bash
 export NEWKERNELVERSION=6.7.8
-sudo dnf upgrade kernel-$NEWKERNELVERSION amlfs-lustre-client-2.15.4_42_gd6d405d-$(echo $NEWKERNELVERSION | sed -e "s/\.$(uname -p)$//" | sed -re 's/[-_]/\./g')-1
+sudo dnf upgrade kernel-$NEWKERNELVERSION amlfs-lustre-client-2.15.5_41_gc010524-$(echo $NEWKERNELVERSION | sed -e "s/\.$(uname -p)$//" | sed -re 's/[-_]/\./g')-1
 ```

--- a/azure-managed-lustre/includes/client-install-version-rhel-7.md
+++ b/azure-managed-lustre/includes/client-install-version-rhel-7.md
@@ -9,7 +9,7 @@ ms.lastreviewed: 02/15/2024
 ---
 
 ```bash
-sudo yum install amlfs-lustre-client-2.15.4_42_gd6d405d-$(uname -r | sed -e "s/\.$(uname -p)$//" | sed -re 's/[-_]/\./g')-1
+sudo yum install amlfs-lustre-client-2.15.5_41_gc010524-$(uname -r | sed -e "s/\.$(uname -p)$//" | sed -re 's/[-_]/\./g')-1
 ```
 
 > [!NOTE]
@@ -19,5 +19,5 @@ If you want to upgrade *only* the kernel and not all packages, you must, at mini
 
 ```bash
 export NEWKERNELVERSION=6.7.8
-sudo yum upgrade kernel-$NEWKERNELVERSION amlfs-lustre-client-2.15.4_42_gd6d405d-$(echo $NEWKERNELVERSION | sed -e "s/\.$(uname -p)$//" | sed -re 's/[-_]/\./g')-1
+sudo yum upgrade kernel-$NEWKERNELVERSION amlfs-lustre-client-2.15.5_41_gc010524-$(echo $NEWKERNELVERSION | sed -e "s/\.$(uname -p)$//" | sed -re 's/[-_]/\./g')-1
 ```

--- a/azure-managed-lustre/includes/client-install-version-rhel-8-9.md
+++ b/azure-managed-lustre/includes/client-install-version-rhel-8-9.md
@@ -9,7 +9,7 @@ ms.lastreviewed: 02/15/2024
 ---
 
 ```bash
-sudo dnf install amlfs-lustre-client-2.15.4_42_gd6d405d-$(uname -r | sed -e "s/\.$(uname -p)$//" | sed -re 's/[-_]/\./g')-1
+sudo dnf install amlfs-lustre-client-2.15.5_41_gc010524-$(uname -r | sed -e "s/\.$(uname -p)$//" | sed -re 's/[-_]/\./g')-1
 ```
 
 > [!NOTE]
@@ -19,5 +19,5 @@ If you want to upgrade *only* the kernel and not all packages, you must, at mini
 
 ```bash
 export NEWKERNELVERSION=6.7.8
-sudo dnf upgrade kernel-$NEWKERNELVERSION amlfs-lustre-client-2.15.4_42_gd6d405d-$(echo $NEWKERNELVERSION | sed -e "s/\.$(uname -p)$//" | sed -re 's/[-_]/\./g')-1
+sudo dnf upgrade kernel-$NEWKERNELVERSION amlfs-lustre-client-2.15.5_41_gc010524-$(echo $NEWKERNELVERSION | sed -e "s/\.$(uname -p)$//" | sed -re 's/[-_]/\./g')-1
 ```

--- a/azure-managed-lustre/includes/client-install-version-ubuntu.md
+++ b/azure-managed-lustre/includes/client-install-version-ubuntu.md
@@ -9,7 +9,7 @@ ms.lastreviewed: 02/15/2024
 ---
 
 ```bash
-sudo apt install amlfs-lustre-client-2.15.4-42-gd6d405d=$(uname -r)
+sudo apt install amlfs-lustre-client-2.15.5-41-gc010524=$(uname -r)
 ```
 
 > [!NOTE]
@@ -18,5 +18,5 @@ sudo apt install amlfs-lustre-client-2.15.4-42-gd6d405d=$(uname -r)
 Optionally, if you want to upgrade *only* the kernel (and not all packages), you must, at minimum, also upgrade the **amlfs-lustre-client** metapackage in order for the Lustre client to continue to work after the reboot. The command should look similar to the following example:
 
 ```bash
-apt upgrade linux-image-[new kernel version] amlfs-lustre-client-2.15.4-42-gd6d405d
+apt upgrade linux-image-[new kernel version] amlfs-lustre-client-2.15.5-41-gc010524
 ```


### PR DESCRIPTION
Update AMLFS Client install instructions to point to new version (2.15.5-41-gc010524).

Remove instructions to disable trusted launch.