### PR TITLE
AMLFS Clients: drop ubuntu 18/rhel7 support

### DIFF
--- a/azure-managed-lustre/client-install.md
+++ b/azure-managed-lustre/client-install.md
@@ -146,6 +146,9 @@ The instructions apply to client VMs running:
 
 ::: zone pivot="rhel-7"
 
+> [!WARNING]
+> We will no longer be publishing any more new AMLFS client packages for Red Hat Enterprise Linux 7 moving forward. Please migrated to one of the supported release to run newer versions of the AMLFS client packages.
+
 1. Install and configure the Azure Managed Lustre repository for the YUM package manager. Create the following script and name it `repo.bash`:
 
    ```bash
@@ -254,6 +257,9 @@ The instructions apply to client VMs running:
 > [!CAUTION]
 > Ubuntu 18.04 LTS reached the end of Standard Support on May 31, 2023. Microsoft recommends either migrating to the next Ubuntu LTS release or upgrading to Ubuntu Pro to gain access to extended security and maintenance from Canonical. For more information, see the [announcement](https://techcommunity.microsoft.com/t5/linux-and-open-source-blog/canonical-ubuntu-18-04-lts-reaching-end-of-standard-support/ba-p/3822623).
 
+> [!WARNING]
+> We will no longer be publishing any more new AMLFS client packages for Ubuntu 18.04 moving forward. Please migrated to one of the supported release to run newer versions of the AMLFS client packages.
+
 1. Ensure you have Ubuntu Pro activated and are on the recommended 5.4 kernel, which is provided by the linux-image-azure metapackage:
 
    ```bash
@@ -284,7 +290,7 @@ The instructions apply to client VMs running:
 
     The following command installs a metapackage that keeps the version of Lustre aligned with the installed kernel. For this to work, you must use `apt full-upgrade` instead of `apt upgrade` when updating your system.
 
-   [!INCLUDE [client-install-version-ubuntu](./includes/client-install-version-ubuntu.md)]
+   [!INCLUDE [client-install-version-ubuntu-18](./includes/client-install-version-ubuntu-18.md)]
 
 ::: zone-end
 

--- a/azure-managed-lustre/client-install.md
+++ b/azure-managed-lustre/client-install.md
@@ -147,7 +147,7 @@ The instructions apply to client VMs running:
 ::: zone pivot="rhel-7"
 
 > [!WARNING]
-> We will no longer be publishing any more new AMLFS client packages for Red Hat Enterprise Linux 7 moving forward. Please migrated to one of the supported release to run newer versions of the AMLFS client packages.
+> We're no longer publishing new client packages for Red Hat Enterprise Linux 7. Please migrate to one of the supported releases to run newer versions of the Azure Managed Lustre client packages.
 
 1. Install and configure the Azure Managed Lustre repository for the YUM package manager. Create the following script and name it `repo.bash`:
 
@@ -254,11 +254,11 @@ The instructions apply to client VMs running:
 
 ::: zone pivot="ubuntu-18"
 
-> [!CAUTION]
+> [!WARNING]
+> We're no longer publishing new client packages for Ubuntu 18.04. Please migrate to one of the supported releases to run newer versions of the Azure Managed Lustre client packages. 
+>
 > Ubuntu 18.04 LTS reached the end of Standard Support on May 31, 2023. Microsoft recommends either migrating to the next Ubuntu LTS release or upgrading to Ubuntu Pro to gain access to extended security and maintenance from Canonical. For more information, see the [announcement](https://techcommunity.microsoft.com/t5/linux-and-open-source-blog/canonical-ubuntu-18-04-lts-reaching-end-of-standard-support/ba-p/3822623).
 
-> [!WARNING]
-> We will no longer be publishing any more new AMLFS client packages for Ubuntu 18.04 moving forward. Please migrated to one of the supported release to run newer versions of the AMLFS client packages.
 
 1. Ensure you have Ubuntu Pro activated and are on the recommended 5.4 kernel, which is provided by the linux-image-azure metapackage:
 

--- a/azure-managed-lustre/includes/client-install-version-rhel-7.md
+++ b/azure-managed-lustre/includes/client-install-version-rhel-7.md
@@ -9,7 +9,7 @@ ms.lastreviewed: 02/15/2024
 ---
 
 ```bash
-sudo yum install amlfs-lustre-client-2.15.5_41_gc010524-$(uname -r | sed -e "s/\.$(uname -p)$//" | sed -re 's/[-_]/\./g')-1
+sudo yum install amlfs-lustre-client-2.15.4_42_gd6d405d-$(uname -r | sed -e "s/\.$(uname -p)$//" | sed -re 's/[-_]/\./g')-1
 ```
 
 > [!NOTE]
@@ -19,5 +19,5 @@ If you want to upgrade *only* the kernel and not all packages, you must, at mini
 
 ```bash
 export NEWKERNELVERSION=6.7.8
-sudo yum upgrade kernel-$NEWKERNELVERSION amlfs-lustre-client-2.15.5_41_gc010524-$(echo $NEWKERNELVERSION | sed -e "s/\.$(uname -p)$//" | sed -re 's/[-_]/\./g')-1
+sudo yum upgrade kernel-$NEWKERNELVERSION amlfs-lustre-client-2.15.4_42_gd6d405d-$(echo $NEWKERNELVERSION | sed -e "s/\.$(uname -p)$//" | sed -re 's/[-_]/\./g')-1
 ```

--- a/azure-managed-lustre/includes/client-install-version-ubuntu-18.md
+++ b/azure-managed-lustre/includes/client-install-version-ubuntu-18.md
@@ -1,0 +1,22 @@
+---
+author: pauljewellmsft
+ms.author: pauljewell
+ms.service: azure-stack
+ms.topic: include
+ms.date: 02/15/2024
+ms.reviewer: dsundarraj
+ms.lastreviewed: 02/15/2024
+---
+
+```bash
+sudo apt install amlfs-lustre-client-2.15.4-42-gd6d405d=$(uname -r)
+```
+
+> [!NOTE]
+> Running `apt search amlfs-lustre-client` doesn't show all available packages for your distro. To see all available `amlfs-lustre-client` packages, run `apt list -a "amlfs-lustre-client*"`.
+
+Optionally, if you want to upgrade *only* the kernel (and not all packages), you must, at minimum, also upgrade the **amlfs-lustre-client** metapackage in order for the Lustre client to continue to work after the reboot. The command should look similar to the following example:
+
+```bash
+apt upgrade linux-image-[new kernel version] amlfs-lustre-client-2.15.4-42-gd6d405d
+```


### PR DESCRIPTION
Bump Ubuntu 18/RHEL7 back down to the older client versions since we no longer support them.

Add warnings at the top saying that we won't publish any new client packages moving forward.

Is it possible for to respond with screenshots of the rhel 7 and ubuntu 18 pivots with the changes applied in the staging environment? I just wanted to make sure that the warnings show up properly

https://learn.microsoft.com/en-us/azure/azure-managed-lustre/client-install?pivots=rhel-7
https://learn.microsoft.com/en-us/azure/azure-managed-lustre/client-install?pivots=ubuntu-18