### PR TITLE
Azure Stack HCI Upgrade - OEM support warning

### DIFF
--- a/azure-stack/hci/upgrade/about-upgrades-23h2.md
+++ b/azure-stack/hci/upgrade/about-upgrades-23h2.md
@@ -14,6 +14,9 @@ ms.reviewer: alkohli
 
 [!INCLUDE [end-of-service-22H2](../includes/end-of-service-22h2.md)]
 
+> [!IMPORTANT]
+> - Consult your hardware OEM before you upgrade Azure Stack HCI. Validate that your OEM supports the version and the upgrade.
+
 This article provides an overview of upgrading your existing Azure Stack HCI system from version 22H2 to version 23H2.
 
 Throughout this article, we refer to Azure Stack HCI, version 23H2 as the *new* version and Azure Stack HCI, version 22H2 as the *old* version.


### PR DESCRIPTION
Before you upgrade from 22h2 to 23H2 you should always consult your OEM first.

I am a Microsoft employee working on HCI with customers and OEMS, where customers have done this upgrade as described an now have an unsupported environment because the OEM didn't suport it

please refer to Dell dopcumentation for instance.
https://dell.github.io/azurestack-docs/docs/hci/supportmatrix/2406/14g-15g_hci/