### PR TITLE
Update deploy-gpu-node-pool.md

### DIFF
--- a/AKS-Hybrid/deploy-gpu-node-pool.md
+++ b/AKS-Hybrid/deploy-gpu-node-pool.md
@@ -73,7 +73,7 @@ Install the Azure Stack HCI, version 23H2 operating system locally on each serve
 On each host machine, navigate to **Control Panel > Add or Remove programs**, uninstall the NVIDIA host driver, then reboot the machine. After the machine reboots, confirm that the driver was successfully uninstalled. Open an elevated PowerShell terminal and run the following command:
 
 ```powershell
-Get-PnpDevice  | select status, class, friendlyname, instanceid | findstr /i /c:"3d video" 
+Get-PnpDevice  | select status, class, friendlyname, instanceid | where {$_.friendlyname -eq "3D Video Controller"}
 ```
 
 You should see the GPU devices appear in an error state as shown in this example output:


### PR DESCRIPTION
The findstr cmdlet crops the output making the instanceid not visible. Using Powershell native cmdlets shows the instanceid and allows the readers to actually copy it.