### PR TITLE
Clarified messaging on MSI

### DIFF
--- a/azure-local/manage/disconnected-operations-overview.md
+++ b/azure-local/manage/disconnected-operations-overview.md
@@ -40,7 +40,7 @@ Disconnected operations for Azure Local support the following services:
 | Azure portal                      | Delivers an Azure portal experience that's similar to Azure Public. |
 | Azure Resource Manager (ARM)      | Manage and utilize subscriptions, resource groups, ARM templates, and Azure Command-Line Interface (CLI). |
 | Role Based Access Control (RBAC)  | Implement RBAC for subscriptions and resource groups. |
-| Managed Service Identity (MSI)    | Access resources with MSI support for user workloads. |
+| Managed Service Identity (MSI)    | Use System Assigned Identity for resource types supporting Managed Service Identity (MSI). |
 | Arc-enabled servers               | Manage VM Guests for Arc VMs on Azure Local. |
 | Arc VMs for Azure Local           | Set up and manage Windows or Linux virtual machines using the disconnected operations feature for Azure Local. |
 | Arc-enabled Kubernetes (K8s)      | Connect and manage Cloud Native Computing Foundation (CNCF) Kubernetes clusters deployed on Azure Local virtual machines, enabling unified configuration and management. |


### PR DESCRIPTION
As user-assigned identities are not supported and only user workloads can be misleading (e.g. MSI for an Arc-VM used by an application deployed on the VM) suggesting rephrasing to specify system assigned identities being the supported type on all resources supporting MSI.