### PR TITLE
Update compare-vm-management-capabilities.md

### DIFF
--- a/azure-local/concepts/compare-vm-management-capabilities.md
+++ b/azure-local/concepts/compare-vm-management-capabilities.md
@@ -93,7 +93,7 @@ The following table compares the management capabilities for Arc VMs, Arc-enable
 | - Insights|✅|✅|❌|
 | - Logs |✅|✅|❌|
 | - Alerts |✅|❌|❌|
-| - Metrics |✅|❌|❌|
+| - Metrics |❌|❌|❌|
 | - Workbooks |❌|✅|❌|
 | **Automation** |
 | - CLI/PS |✅|✅|❌|


### PR DESCRIPTION
Disabled Metrics for Arc VMs as well, per feedback from Varun. Looks like this is only available for Azure VMs. We can also delete the whole row. I am OK with both. Alpa you can decide.