### PR TITLE
Fixed misleading table headers (hh:mm replacing hh:mm:ss)

### DIFF
--- a/azure-local/update/update-via-powershell-23h2.md
+++ b/azure-local/update/update-via-powershell-23h2.md
@@ -44,7 +44,7 @@ The time taken to install the updates varies based on the following factors:
 
 The approximate time estimates for a typical single or multi-node system are summarized in the following table:
 
-|System/Time           |Time for health check<br>*hh:mm:ss*  |Time to install update<br>*hh:mm:ss*  |
+|System/Time           |Time for health check<br>*hh:mm*  |Time to install update<br>*hh:mm*  |
 |------------------|-------------------------------------|---------|
 |Single node     | ~ 03:00        |~ 01:30         |
 |4-nodes    | ~ 05:00       |~ 04:00         |


### PR DESCRIPTION
The table listing estimated time for health check and update installation has headers which mention **hh:mm:ss**, but the times listed in the body of the table are in XX:XX format. 

I removed **:ss** from the column titles.