### PR TITLE
Add Ubuntu 24.04 install instructions for AMLFS Clients

### DIFF
--- a/azure-managed-lustre/client-install.md
+++ b/azure-managed-lustre/client-install.md
@@ -363,6 +363,75 @@ This article shows how to install the client package to set up client VMs runnin
 
 ::: zone-end
 
+::: zone pivot="ubuntu-24"
+
+> [!IMPORTANT]
+> The Azure Marketplace image for the Ubuntu 24.04 LTS release uses the Hardware Enablement (HWE) kernel by default. However, HWE kernels are supported only for six-month periods, and Lustre support for these kernels is often not available when they're released. We recommend that you switch to the LTS kernel because it gives you more stability and it maintains a kernel version that's supported with the Lustre client.
+
+1. Install the LTS kernel metapackage:
+
+   ```bash
+   sudo apt update && sudo apt install linux-image-azure-lts-24.04
+   ```
+
+1. Remove the default (HWE) kernel metapackage. The response to the following command also asks you to remove the `linux-azure` metapackage.
+
+   ```bash
+   sudo apt remove linux-image-azure
+   ```
+
+1. List installed kernels and see which one the LTS metapackage supplies:
+
+   ```bash
+   apt list --installed linux-image*
+   ```
+
+   Newly provisioned hosts have two kernels, and older hosts might have more. Compare the version that the LTS metapackage provides against the other installed kernels.
+
+1. Remove any kernels newer than the one mentioned in the LTS metapackage.
+
+   ```bash
+   sudo apt remove linux-image-5.15.0-1053-azure
+   ```
+
+   You receive a warning about removing the kernels, but these steps work if you're following them on a newly provisioned host. If you have concerns, consult Ubuntu documentation on configuring kernels to ensure that they can start after a restart.
+
+1. List installed kernels again to verify that you don't have kernels newer than the one mentioned in the LTS metapackage:
+
+   ```bash
+   apt list --installed linux-image*
+   ```
+
+1. Restart to load the LTS kernel.
+
+1. Install and configure the Azure Managed Lustre repository for the APT package manager. Create the following script and name it `repo.bash`:
+
+   ```bash
+    #!/bin/bash
+    set -ex
+    
+    apt update && apt install -y ca-certificates curl apt-transport-https lsb-release gnupg
+    source /etc/lsb-release
+    echo "deb [arch=amd64] https://packages.microsoft.com/repos/amlfs-${DISTRIB_CODENAME}/ ${DISTRIB_CODENAME} main" | tee /etc/apt/sources.list.d/amlfs.list
+    curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null
+    
+    apt update
+   ```
+
+1. Run the script as a superuser:
+
+   ```bash
+   sudo bash repo.bash
+   ```
+
+1. Install the metapackage that matches your running kernel.
+
+    The following command installs a metapackage that keeps the version of Lustre aligned with the installed kernel. For this alignment to work, you must use `apt full-upgrade` instead of `apt upgrade` when updating your system.
+
+   [!INCLUDE [client-install-version-ubunt-24](./includes/client-install-version-ubuntu-24.md)]
+
+::: zone-end
+
 ## Related content
 
 - [Connect clients to an Azure Managed Lustre file system](connect-clients.md)

--- a/azure-managed-lustre/client-upgrade.md
+++ b/azure-managed-lustre/client-upgrade.md
@@ -59,7 +59,7 @@ If your client machine uses an older version of Lustre, you can upgrade the Lust
 
     If the output shows an old version of the Lustre kernel module, we recommend that you restart (`sudo reboot`) the system.
 
-### [Ubuntu](#tab/ubuntu)
+### [Ubuntu 20.04/22.04](#tab/ubuntu)
 
 1. Unmount any containers or mount points that are mounting the Lustre client by using the following command:
 
@@ -97,6 +97,43 @@ If your client machine uses an older version of Lustre, you can upgrade the Lust
 
     If the output shows an old version of the Lustre kernel module, we recommend that you restart (`sudo reboot`) the system.
 
+### [Ubuntu 24.04](#tab/ubuntu24)
+
+1. Unmount any containers or mount points that are mounting the Lustre client by using the following command:
+
+    ```bash
+    sudo umount <all Lustre mounts>
+    ```
+
+1. Uninstall the existing Lustre client version by using the following command:
+
+    ```bash
+    sudo apt autoremove *lustre* -y
+    ```
+
+1. Install the current version of the Lustre client by using the following command:
+
+    [!INCLUDE [client-upgrade-version-ubuntu](./includes/client-upgrade-version-ubuntu-24.md)]
+
+1. Unload the Lustre and Lustre Networking (LNet) kernel modules by using the following command:
+
+    ```bash
+    sudo lustre_rmmod
+    ```
+
+1. Verify that old kernel modules are removed by using the following command:
+
+    ```bash
+    cat /sys/module/lustre/version; lsmod | grep -E 'lustre|lnet'
+    ```
+
+    The output should look similar to the following example:
+
+    ```bash
+    cat: /sys/module/lustre/version: No such file or directory
+    ```
+
+    If the output shows an old version of the Lustre kernel module, we recommend that you restart (`sudo reboot`) the system.
 ---
 
 After you perform this procedure, you can [mount the client](connect-clients.md#start-the-lustre-client-by-using-the-mount-command) to your Azure Managed Lustre file system.

--- a/azure-managed-lustre/includes/client-install-version-ubuntu-24.md
+++ b/azure-managed-lustre/includes/client-install-version-ubuntu-24.md
@@ -1,0 +1,25 @@
+---
+author: pauljewellmsft
+ms.author: pauljewell
+ms.service: azure-stack
+ms.topic: include
+ms.date: 10/18/2024
+ms.reviewer: dsundarraj
+ms.lastreviewed: 10/18/2024
+---
+
+> [!NOTE]
+> 2.16 is a non-LTS release of Lustre and will stop receiving support from the community soon after the release of 2.17. Please check back in late 2025/early 2026 for more information about the 2.17 release.
+
+```bash
+sudo apt install amlfs-lustre-client-2.16.1-14-gbc76088=$(uname -r)
+```
+
+> [!NOTE]
+> Running `apt search amlfs-lustre-client` doesn't show all available packages for your distribution. To see all available `amlfs-lustre-client` packages, run `apt list -a "amlfs-lustre-client*"`.
+
+Optionally, if you want to upgrade *only* the kernel and not all packages, you must (at minimum) also upgrade the `amlfs-lustre-client` metapackage so that the Lustre client can continue to work after the restart. The command should look similar to the following example:
+
+```bash
+apt upgrade linux-image-[new kernel version] amlfs-lustre-client-2.16.1-14-gbc76088
+```

--- a/azure-managed-lustre/includes/client-upgrade-version-ubuntu-24.md
+++ b/azure-managed-lustre/includes/client-upgrade-version-ubuntu-24.md
@@ -1,0 +1,13 @@
+---
+author: pauljewellmsft
+ms.author: pauljewell
+ms.service: azure-stack
+ms.topic: include
+ms.date: 10/24/2024
+ms.reviewer: 
+ms.lastreviewed: 
+---
+
+```bash
+sudo apt install -y amlfs-lustre-client-2.16.1-14-gbc76088=$(uname -r)
+```


### PR DESCRIPTION
Add a new tab for Ubuntu 22.04 install instructions for AMLFS clients.

Since it's a new tab, some video/screenshots of scrolling through the new page in the staging environment would be appreciated to make sure that the new includes are working properly.

These are the public facing pages that should be affected, both should have a new "Ubuntu 24.04" tab:

https://learn.microsoft.com/en-us/azure/azure-managed-lustre/client-install

https://learn.microsoft.com/en-us/azure/azure-managed-lustre/client-upgrade