### PR TITLE
Fix wrong parameter name

### DIFF
--- a/AKS-Arc/disable-windows-nodepool.md
+++ b/AKS-Arc/disable-windows-nodepool.md
@@ -90,7 +90,7 @@ az k8s-extension update --resource-group $resourceGroup --cluster-name $clusterN
 If for some reason you're not able to use Azure CloudShell or a machine with connectivity to Azure in order to disable Windows nodepool, you can disable Windows nodepool after connecting to any one of the Azure Local physical nodes with Remote Desktop. You must first sign in to Azure.
 
 ```powershell
-az login --use-device-code --tenant-id <Azure tenant ID>
+az login --use-device-code --tenant <Azure tenant ID>
  
 az account set -s <subscription ID>
  


### PR DESCRIPTION
According to https://learn.microsoft.com/en-us/cli/azure/reference-index?view=azure-cli-latest#az-login the correct parameter name for passing tenant id to az login is --tenant and not --tenant-id.