### PR TITLE
Document permitted actions in Enabled Degraded State

### DIFF
--- a/operator-nexus/howto-replace-network-devices.md
+++ b/operator-nexus/howto-replace-network-devices.md
@@ -177,6 +177,41 @@ This action sets the following state once it's fully healthy and synchronized wi
 >[!Note]
 > In a given fabric if there are any other device is in Disabled state then the Fabric Administrative State will maintained as : `EnabledDegraded` 
 
+### **Permitted/Non-Permitted Actions When Fabric is in Enabled Degraded State**
+
+When the fabric is in an **Enabled Degraded State**, certain operations are permitted while others should be deferred or handled with caution. Please refer to the below list:
+
+---
+
+#### **Following are the Permitted Operations**
+
+| **Operation Category** | **Examples (APIs / CLI)** | **Allowed?** | **Notes / Recommended Practice** |
+|---|---|---|---|
+| **READ (non-mutating)** | GET/List, Show for Fabric / Devices / ISDs / Networks; metrics & health | **Allowed** | Safe to monitor state, validate results, and track onboarding |
+| **RMA Device Replacement Actions** | Disable + Update Serial + RMA + Refresh Config + Enable | **Allowed** | Follow standard Replace Device guide steps |
+| **Commit (configuration apply)** | Start / Monitor Commit (Commit Workflow v2) | **Allowed** | Configurations pushed to all devices except those in Disabled state |
+| **VALIDATE (pre-flight checks)** | Validate configuration / dry-runs | **Allowed** | Useful to catch issues before commit |
+| **Administrative Lock / Unlock** | Lock / Unlock fabric | **Allowed** | No restrictions in this state |
+
+---
+
+#### **Following Operations are Technically Allowed but Recommended to Defer**
+
+| **Operation Category** | **Examples (APIs / CLI)** | **Allowed?** | **Notes / Recommended Practice** |
+|---|---|---|---|
+| **CREATE/UPDATE config (non-RMA config)** | Add/Change ISDs, Networks, Route Policies, Prefs/vias, Taps, Communities | Technically allowed but defer if possible | Configuration won’t reach Disabled devices until RMA completes. Once device RMA completed all latest configuration will be pushed to devices. |
+| **DELETE (fabric config)** | Remove ISDs, Networks, Policies, Taps | Technically allowed but defer if possible | Disabled devices may retain removed config until re-enabled. |
+
+---
+
+#### **Non-permitted Operations**
+
+| **Operation Category** | **Examples (APIs/CLI)** | **Allowed?** | **Notes / Recommended Practice** |
+|---|---|---|---|
+| **Upgrades** | Fabric/Device runtime upgrades | **Not permitted** | Schedule upgrades after RMA completes and fabric returns to Enabled |
+| **Secret rotation** | Geneva action | **Not permitted** | TS reprovisioning and device RMA would be treated as mutually exclusive operations. If one is active the other cannot be initiated. |
+
+
 ## Summary
 
 The RMA workflow in Network Fabric ensures seamless device replacement with controlled state transitions and full configuration synchronization. This helps maintain service continuity and operational consistency across the network.


### PR DESCRIPTION
Added guidelines for permitted and non-permitted actions when the fabric is in an Enabled Degraded State, including specific operations and recommended practices.