### PR TITLE
replace Arc gateway resource ID with Subscription ID placeholder

### DIFF
--- a/azure-local/deploy/deployment-with-azure-arc-gateway.md
+++ b/azure-local/deploy/deployment-with-azure-arc-gateway.md
@@ -324,6 +324,10 @@ $Tenant = "YourTenantID"
 #Define the subscription where you want to register your Azure Local machine with Arc.
 $Subscription = "yoursubscriptionID" 
 
+#Define the region to use to register your server as Arc device
+#Do not use spaces or capital letters when defining region
+$Region = "eastus"
+
 #Define the resource group where you want to register your Azure Local machine with Arc.
 $RG = "yourresourcegroupname" 
 

--- a/azure-local/deploy/deployment-with-azure-arc-gateway.md
+++ b/azure-local/deploy/deployment-with-azure-arc-gateway.md
@@ -84,7 +84,7 @@ This article details how to register Azure Local using Azure Arc gateway and wit
     $ProxyBypassList = "localhost,127.0.0.1,*.contoso.com,machine1,machine2,machine3,machine4,machine5,192.168.*.*,AzureLocal-1" 
 
     #Define the Arc gateway resource ID from Azure 
-    $ArcgwId = "/subscriptions/yourarcgatewayid/resourceGroups/yourResourceGroupName/providers/Microsoft.HybridCompute/gateways/yourArcGatewayName" 
+    $ArcgwId = "/subscriptions/yoursubscription/resourceGroups/yourResourceGroupName/providers/Microsoft.HybridCompute/gateways/yourArcGatewayName" 
     ```
 
 ## Step 3: Run registration script
@@ -328,7 +328,7 @@ $Subscription = "yoursubscriptionID"
 $RG = "yourresourcegroupname" 
 
 #Define the Arc gateway resource ID from Azure 
-$ArcgwId = "/subscriptions/yourarcgatewayid/resourceGroups/yourresourcegroupname/providers/Microsoft.HybridCompute/gateways/yourarcgatewayname" 
+$ArcgwId = "/subscriptions/yoursubscription/resourceGroups/yourresourcegroupname/providers/Microsoft.HybridCompute/gateways/yourarcgatewayname" 
 ```
 
 ## Step 3: Run the registration script

--- a/azure-local/deploy/deployment-with-azure-arc-gateway.md
+++ b/azure-local/deploy/deployment-with-azure-arc-gateway.md
@@ -84,7 +84,7 @@ This article details how to register Azure Local using Azure Arc gateway and wit
     $ProxyBypassList = "localhost,127.0.0.1,*.contoso.com,machine1,machine2,machine3,machine4,machine5,192.168.*.*,AzureLocal-1" 
 
     #Define the Arc gateway resource ID from Azure 
-    $ArcgwId = "/subscriptions/yoursubscription/resourceGroups/yourResourceGroupName/providers/Microsoft.HybridCompute/gateways/yourArcGatewayName" 
+    $ArcgwId = "/subscriptions/yoursubscriptionid/resourceGroups/yourResourceGroupName/providers/Microsoft.HybridCompute/gateways/yourArcGatewayName" 
     ```
 
 ## Step 3: Run registration script
@@ -328,7 +328,7 @@ $Subscription = "yoursubscriptionID"
 $RG = "yourresourcegroupname" 
 
 #Define the Arc gateway resource ID from Azure 
-$ArcgwId = "/subscriptions/yoursubscription/resourceGroups/yourresourcegroupname/providers/Microsoft.HybridCompute/gateways/yourarcgatewayname" 
+$ArcgwId = "/subscriptions/yoursubscriptionid/resourceGroups/yourresourcegroupname/providers/Microsoft.HybridCompute/gateways/yourarcgatewayname" 
 ```
 
 ## Step 3: Run the registration script


### PR DESCRIPTION
If I copy the resource ID from Azure portal as described  it has pattern /subscription/mysubscritptionID/resourceGroups/... and not  /subscription/myarcgatewayID/resourceGroups/... I didn't test it, because my deployment is without a proxy and I only use the ArcgatewayID - but this looks like a typo.