### PR TITLE
Update OS version to 24H2 in installation guide

### DIFF
--- a/azure-local/deploy/deployment-install-os.md
+++ b/azure-local/deploy/deployment-install-os.md
@@ -1,6 +1,6 @@
 ---
-title: Install Azure Stack HCI operating system, version 23H2
-description: Learn how to install the Azure Stack HCI operating system, version 23H2 on each machine of your system.
+title: Install Azure Stack HCI operating system, version 24H2
+description: Learn how to install the Azure Stack HCI operating system, version 24H2 on each machine of your system.
 author: alkohli
 ms.topic: how-to
 ms.date: 12/11/2025

--- a/azure-local/deploy/deployment-install-os.md
+++ b/azure-local/deploy/deployment-install-os.md
@@ -1,6 +1,6 @@
 ---
-title: Install Azure Stack HCI operating system, version 24H2
-description: Learn how to install the Azure Stack HCI operating system, version 24H2 on each machine of your system.
+title: Install Azure Stack HCI operating system, version 24H2 using sconfig
+description: Learn how to install the Azure Stack HCI operating system, version 24H2 on each machine of your system using sconfig.
 author: alkohli
 ms.topic: how-to
 ms.date: 12/11/2025


### PR DESCRIPTION
minor edits to reflect the 24H2 change as 23H2 can no longer be deployed and is unsupported.