### PR TITLE
Update hci-registration-azure-prerequisites.md

### DIFF
--- a/azure-local/includes/hci-registration-azure-prerequisites.md
+++ b/azure-local/includes/hci-registration-azure-prerequisites.md
@@ -26,6 +26,7 @@ ms.lastreviewed: 03/20/2025
    Register-AzResourceProvider -ProviderNamespace "Microsoft.Attestation"
    Register-AzResourceProvider -ProviderNamespace "Microsoft.Storage"
    Register-AzResourceProvider -ProviderNamespace "Microsoft.Insights"
+   Register-AzResourceProvider -ProviderNamespace "Microsoft.KeyVault"
    ```
 
     > [!NOTE]


### PR DESCRIPTION
To register the cluster, Key Vault is required, and since it is not registered by default in the subscription, I add it at the end line.