### PR TITLE
Update azure-stack-compute-add-scalesets.md

### DIFF
--- a/azure-stack/operator/azure-stack-compute-add-scalesets.md
+++ b/azure-stack/operator/azure-stack-compute-add-scalesets.md
@@ -34,7 +34,7 @@ On Azure Stack Hub, virtual machine scale sets do not support autoscale. You can
 
 ## Use the Azure Stack Hub portal
 
-1. Sign in to the Azure Stack Hub portal. Then, go to **All services**, then **Virtual machine scale sets**, and then under **COMPUTE**, select **Virtual machine scale sets**.
+1. Sign in to the Azure Stack Hub admin portal or tenant portal. Then, go to **All services**, then **Virtual machine scale sets**, and then under **COMPUTE**, select **Virtual machine scale sets**.
    [![Select virtual machine scale sets](media/azure-stack-compute-add-scalesets/all-services-small.png)](media/azure-stack-compute-add-scalesets/all-services.png#lightbox)
 
 2. Select **Add**.

--- a/azure-stack/operator/azure-stack-compute-add-scalesets.md
+++ b/azure-stack/operator/azure-stack-compute-add-scalesets.md
@@ -37,14 +37,16 @@ On Azure Stack Hub, virtual machine scale sets do not support autoscale. You can
 
    [![Select virtual machine scale sets](media/azure-stack-compute-add-scalesets/all-services-small.png)](media/azure-stack-compute-add-scalesets/all-services.png#lightbox)
 
-3. Select **Add**.
+1. Select **Add**.
 
    ![Create a virtual machine scale set](media/azure-stack-compute-add-scalesets/create-scale-set.png)
 
-4. Fill in the empty fields, choose from the dropdowns for **Operating system disk image**, **Subscription**, and **Instance size**. Select **Yes** for **Use managed disks**. Then, select **Create**.
+1. Fill in the empty fields, choose from the dropdowns for **Operating system disk image**, **Subscription**, and **Instance size**. Select **Yes** for **Use managed disks**. Then, select **Create**.
+
     [![Configure and create virtual machine scale sets](media/azure-stack-compute-add-scalesets/create-small.png)](media/azure-stack-compute-add-scalesets/create.png#lightbox)
 
-5. To see your new virtual machine scale set, go to **All resources**, search for the virtual machine scale set name, and then select its name in the search.
+1. To see your new virtual machine scale set, go to **All resources**, search for the virtual machine scale set name, and then select its name in the search.
+
    [![View the virtual machine scale set](media/azure-stack-compute-add-scalesets/search-small.png)](media/azure-stack-compute-add-scalesets/search.png#lightbox)
 
 ## Update images in a virtual machine scale set
@@ -66,7 +68,7 @@ After you create a virtual machine scale set, users can update images in the sca
         }
     ```
 
-2. Virtual machine scale set deployment template **does not specify latest** for **version** and specifies a version number instead:  
+1. Virtual machine scale set deployment template **does not specify latest** for **version** and specifies a version number instead:  
 
     If the Azure Stack operator downloads an image with a newer version (and deletes the older version), the scale set cannot scale up. This is by design, as the image version specified in the scale set template must be available.  
 
@@ -78,10 +80,10 @@ You can change the size of a virtual machine scale set to make it larger or smal
 
 1. In the portal, select your scale set and then select **Scaling**.
 
-2. Use the slide bar to set the new level of scaling for this virtual machine scale set, and then click **Save**.
+1. Use the slide bar to set the new level of scaling for this virtual machine scale set, and then click **Save**.
 
      [![Scale the virtual machine set](media/azure-stack-compute-add-scalesets/scale-small.png)](media/azure-stack-compute-add-scalesets/scale.png#lightbox)
 
 ## Next steps
 
-* [Download marketplace items from Azure to Azure Stack Hub](azure-stack-download-azure-marketplace-item.md)
+[Download marketplace items from Azure to Azure Stack Hub](azure-stack-download-azure-marketplace-item.md)

--- a/azure-stack/operator/azure-stack-compute-add-scalesets.md
+++ b/azure-stack/operator/azure-stack-compute-add-scalesets.md
@@ -3,9 +3,8 @@ title: Make virtual machine scale sets available in Azure Stack Hub
 description: Learn how a cloud operator can add virtual machine scale sets to Azure Stack Hub Marketplace.
 author: sethmanheim
 ms.topic: install-set-up-deploy
-ms.date: 07/22/2021
+ms.date: 04/28/2026
 ms.author: sethm
-ms.reviewer: unknown
 ms.lastreviewed: 10/22/2019
 ms.custom: sfi-image-nochange
 
@@ -34,17 +33,18 @@ On Azure Stack Hub, virtual machine scale sets do not support autoscale. You can
 
 ## Use the Azure Stack Hub portal
 
-1. Sign in to the Azure Stack Hub admin portal or tenant portal. Then, go to **All services**, then **Virtual machine scale sets**, and then under **COMPUTE**, select **Virtual machine scale sets**.
+1. Sign in to the Azure Stack Hub admin portal or tenant portal. Then, go to **All services**, then **Virtual machine scale sets**, and then under **COMPUTE**, select **Virtual machine scale sets**. The screenshots in this section are from the admin portal using the default provider subscription. You can also follow the same steps from the tenant portal when creating VM Scale Sets.
+
    [![Select virtual machine scale sets](media/azure-stack-compute-add-scalesets/all-services-small.png)](media/azure-stack-compute-add-scalesets/all-services.png#lightbox)
 
-2. Select **Add**.
+3. Select **Add**.
 
    ![Create a virtual machine scale set](media/azure-stack-compute-add-scalesets/create-scale-set.png)
 
-3. Fill in the empty fields, choose from the dropdowns for **Operating system disk image**, **Subscription**, and **Instance size**. Select **Yes** for **Use managed disks**. Then, select **Create**.
+4. Fill in the empty fields, choose from the dropdowns for **Operating system disk image**, **Subscription**, and **Instance size**. Select **Yes** for **Use managed disks**. Then, select **Create**.
     [![Configure and create virtual machine scale sets](media/azure-stack-compute-add-scalesets/create-small.png)](media/azure-stack-compute-add-scalesets/create.png#lightbox)
 
-4. To see your new virtual machine scale set, go to **All resources**, search for the virtual machine scale set name, and then select its name in the search.
+5. To see your new virtual machine scale set, go to **All resources**, search for the virtual machine scale set name, and then select its name in the search.
    [![View the virtual machine scale set](media/azure-stack-compute-add-scalesets/search-small.png)](media/azure-stack-compute-add-scalesets/search.png#lightbox)
 
 ## Update images in a virtual machine scale set


### PR DESCRIPTION
All the screenshots and steps in this document are taken from the Azure Stack Hub Admin portal and use the Default Provider Subscription. However, the document does not explicitly state which portal (Admin or Tenant) should be used to create Virtual Machine Scale Sets (VMSS).

This lack of clarity may cause confusion for readers, as VMSS can also be created from the Tenant portal using the same workflow. The documentation should clearly specify:

That the screenshots reflect actions performed in the Admin portal using the Default Provider Subscription, and That the same steps can also be followed from the Tenant portal when creating VM Scale Sets. Adding this clarification will improve usability and prevent ambiguity for operators and tenants following the guide.