### PR TITLE
Enhance OS image update details during Arc registration

### DIFF
--- a/azure-local/includes/azure-local-handle-os-image-update-during-arc-registration.md
+++ b/azure-local/includes/azure-local-handle-os-image-update-during-arc-registration.md
@@ -7,10 +7,10 @@ ms.date: 02/11/2026
 ms.reviewer: alkohli
 ---
 
-During Azure Arc registration, Azure Local verifies whether the OS image is current for its release baseline. If the image is outdated or unsupported, the system automatically updates it during registration. You can optionally specify a target solution version using the `TargetSolutionVersion` parameter.
+During Azure Arc registration, Azure Local verifies whether the OS image is current for its release baseline. If the image is outdated or unsupported, the system automatically detects it during initialization and provides a list of available update versions to select from. You can proactively specify a target solution version using the optional `TargetSolutionVersion` parameter.
 
-- The update typically takes 40-45 minutes.
-- A system reboot is required.
+- The update typically takes 40-45 minutes followed by a reboot.
+- Rerun `Invoke-AzStackHciArcInitialization` cmdlet post reboot.
 - During the update, the registration status appears as **Update: InProgress**.
 
    :::image type="content" source="media/azure-local-handle-os-image-update-during-arc-registration/operating-system-image-update-registration.png" alt-text="Screenshot of the console window with the registration in progress." lightbox="media/azure-local-handle-os-image-update-during-arc-registration/operating-system-image-update-registration.png":::


### PR DESCRIPTION
Updated the OS image update process description during Azure Arc registration to include detection of outdated images and the option to select from available versions. Added a note about rerunning the initialization cmdlet after reboot.


@manika please help me update this screenshot in the doc. This will be a replacement of the screenshot which already exists in this section. Thank you!
<img width="1485" height="817" alt="image (1)" src="https://github.com/user-attachments/assets/e3602c48-e67f-4428-9440-84412ac845fe" />

