### PR TITLE
Enhance cluster upgrade overview with detailed process

### DIFF
--- a/operator-nexus/concepts-cluster-upgrade-overview.md
+++ b/operator-nexus/concepts-cluster-upgrade-overview.md
@@ -43,7 +43,7 @@ The runtime upgrade starts by upgrading the three management servers designated 
 
 > [!Note]
 > Customers may observe the spare server with a different runtime version. This is expected.
-> If the EnableRepurposeSpareKcpNode feature is enabled, a healthy management plane node is first promoted to a spare control plane node before the control plane upgrade begins. After all control plane nodes are upgraded, the spare control plane node is converted back to a management plane node.
+> If the internal feature flag `EnableRepurposeSpareKcpNode` is enabled, a healthy management server/node is temporarily repurposed as the spare control plane server/node before the control plane upgrade begins. After all control plane nodes are upgraded, that spare control plane server/node is converted back to a management server/node.
 
 Once all management servers are upgraded, the upgrade progresses to the compute servers. Each rack is upgraded in alphanumeric order, and there are various configurations customers can use to dictate how the computes are upgrade to best limit disruption. As each rack progresses, there are various health checks performed in order to ensure the release successfully upgrades and a sufficient number of computes in a rack returns to operational status. When a rack completes, a customer defined waits time starts to provide extra time for workloads to come online. Once each rack upgrades, the upgrade completes and the cluster returns to `Running` status. 
 

--- a/operator-nexus/concepts-cluster-upgrade-overview.md
+++ b/operator-nexus/concepts-cluster-upgrade-overview.md
@@ -43,6 +43,7 @@ The runtime upgrade starts by upgrading the three management servers designated 
 
 > [!Note]
 > Customers may observe the spare server with a different runtime version. This is expected.
+> If the EnableRepurposeSpareKcpNode feature is enabled, a healthy management plane node is first promoted to a spare control plane node before the control plane upgrade begins. After all control plane nodes are upgraded, the spare control plane node is converted back to a management plane node.
 
 Once all management servers are upgraded, the upgrade progresses to the compute servers. Each rack is upgraded in alphanumeric order, and there are various configurations customers can use to dictate how the computes are upgrade to best limit disruption. As each rack progresses, there are various health checks performed in order to ensure the release successfully upgrades and a sufficient number of computes in a rack returns to operational status. When a rack completes, a customer defined waits time starts to provide extra time for workloads to come online. Once each rack upgrades, the upgrade completes and the cluster returns to `Running` status. 
 


### PR DESCRIPTION
Clarified the process of upgrading management servers and compute servers during the runtime upgrade. Added details about the EnableRepurposeSpareKcpNode feature and its impact on control plane nodes.

Add changes in Upgrade behavior observed due to EnableRepurposeSpareKcpNode feature. 

