### PR TITLE
Update LTS end of life for 1.30

### DIFF
--- a/operator-nexus/includes/kubernetes-cluster/supported-versions.md
+++ b/operator-nexus/includes/kubernetes-cluster/supported-versions.md
@@ -11,7 +11,7 @@ ms.service: azure-operator-nexus
 | 1.27         | Sep 2023  | Jul 2024        | Jul 2025        | NA                    |
 | 1.28         | Nov 2023  | Jan 2025        | NA              | Until end of Oct 2025 |
 | 1.29         | Aug 2024  | Mar 2025        | NA              | Until end of Feb 2026 |
-| 1.30         | Oct 2024  | Jul 2025        | Jul 2026        | NA                    |
+| 1.30         | Oct 2024  | Jul 2025        | Jun 2026        | NA                    |
 | 1.31         | Mar 2025  | Nov 2025        | Nov 2026        | NA                    |
 | 1.32         | Apr 2025  | Mar 2026        | Mar 2027        | NA                    |
 | 1.33         | Jul 2025  | Jun 2026        | Jun 2027        | NA                    |


### PR DESCRIPTION
Date for the nexus supported kubernetes clusters 1.30 end of date is wrong and this corrects it to what is expected.