### PR TITLE
Add Microsoft.Compute entry to subscription setup

### DIFF
--- a/azure-local/small-form-factor/small-form-factor-subscription-setup.md
+++ b/azure-local/small-form-factor/small-form-factor-subscription-setup.md
@@ -34,6 +34,7 @@ Your subscription must have the following resource providers registered. Some pr
 | `Microsoft.Edge` | All use cases | [Site, site configuration](/azure/templates/microsoft.edge/sites?pivots=deployment-language-bicep) |
 | `Microsoft.AzureStackHCI` | All use cases | [Edge machine (also known as provisioned machine)](/azure/templates/microsoft.azurestackhci/edgemachines?pivots=deployment-language-bicep) |
 | `Microsoft.HybridCompute` | All use cases | [Arc-connected machines in the managed resource group](/azure/templates/microsoft.hybridcompute/machines?pivots=deployment-language-bicep) |
+| `Microsoft.Compute` | All use cases | [VM resources](https://learn.microsoft.com/en-us/azure/templates/microsoft.compute/virtualmachines?pivots=deployment-language-bicep) |
 | `Microsoft.GuestConfiguration` | All use cases | [Guest configuration assignments in the managed resource group](/azure/templates/microsoft.guestconfiguration/guestconfigurationassignments?pivots=deployment-language-bicep) |
 | `Microsoft.HybridConnectivity` | All use cases | [Connectivity endpoints for Arc-connected machines](/azure/templates/microsoft.hybridconnectivity/endpoints?pivots=deployment-language-bicep) |
 | `Microsoft.KeyVault` | All use cases | [Key vault for managing secrets](/azure/templates/microsoft.keyvault/vaults?pivots=deployment-language-bicep) |

--- a/azure-local/small-form-factor/small-form-factor-subscription-setup.md
+++ b/azure-local/small-form-factor/small-form-factor-subscription-setup.md
@@ -34,7 +34,7 @@ Your subscription must have the following resource providers registered. Some pr
 | `Microsoft.Edge` | All use cases | [Site, site configuration](/azure/templates/microsoft.edge/sites?pivots=deployment-language-bicep) |
 | `Microsoft.AzureStackHCI` | All use cases | [Edge machine (also known as provisioned machine)](/azure/templates/microsoft.azurestackhci/edgemachines?pivots=deployment-language-bicep) |
 | `Microsoft.HybridCompute` | All use cases | [Arc-connected machines in the managed resource group](/azure/templates/microsoft.hybridcompute/machines?pivots=deployment-language-bicep) |
-| `Microsoft.Compute` | All use cases | [VM resources](https://learn.microsoft.com/en-us/azure/templates/microsoft.compute/virtualmachines?pivots=deployment-language-bicep) |
+| `Microsoft.Compute` | All use cases | [VM resources](https://learn.microsoft.com/azure/templates/microsoft.compute/virtualmachines?pivots=deployment-language-bicep) |
 | `Microsoft.GuestConfiguration` | All use cases | [Guest configuration assignments in the managed resource group](/azure/templates/microsoft.guestconfiguration/guestconfigurationassignments?pivots=deployment-language-bicep) |
 | `Microsoft.HybridConnectivity` | All use cases | [Connectivity endpoints for Arc-connected machines](/azure/templates/microsoft.hybridconnectivity/endpoints?pivots=deployment-language-bicep) |
 | `Microsoft.KeyVault` | All use cases | [Key vault for managing secrets](/azure/templates/microsoft.keyvault/vaults?pivots=deployment-language-bicep) |


### PR DESCRIPTION
Added Microsoft.Compute entry with VM resources link.

Hit a snag when I was trying to set this up, needed to have the Microsoft compute resource rp added to your subscription in order to get the ssh key download in step 3 when you provision the VM. I have added that piece to the instructions in hope others don't have the same issue.