### PR TITLE
Update aks-bare-metal-deploy-application.md

### DIFF
--- a/AKS-Arc/aks-bare-metal-deploy-application.md
+++ b/AKS-Arc/aks-bare-metal-deploy-application.md
@@ -26,7 +26,7 @@ Follow the steps below to deploy a nginx deployment on your AKS on bare metal cl
 ### Step 1: Create the deployment
 
 ```bash
-kubectl create deployment nginx --image=mcr.microsoft.com/cbl-mariner/base/nginx:1.24
+kubectl create deployment nginx --image=mcr.microsoft.com/cbl-mariner/base/nginx:1.22
 ```
 
 ### Step 2: Verify the pod is running

--- a/AKS-Arc/aks-bare-metal-deploy-application.md
+++ b/AKS-Arc/aks-bare-metal-deploy-application.md
@@ -94,7 +94,7 @@ spec:
     spec:
       containers:
       - name: hello-app
-        image: mcr.microsoft.com/cbl-mariner/base/nginx:1.24
+        image: mcr.microsoft.com/cbl-mariner/base/nginx:1.22
         ports:
         - containerPort: 80
         resources:


### PR DESCRIPTION
There is no 1.24 in the repository Nginx goes to 1.22, this command created an error when I was testing it. Please see:

https://mcr.microsoft.com/en-us/artifact/mar/cbl-mariner/base/nginx/tags