### PR TITLE
Update manage-secrets-rotation.md with parameter notes

### DIFF
--- a/azure-local/manage/manage-secrets-rotation.md
+++ b/azure-local/manage/manage-secrets-rotation.md
@@ -33,6 +33,9 @@ The `Set-AzureStackLCMUserPassword` cmdlet takes the following parameters:
 |`NewPassword` | The new password for the user.        |
 |`UpdateAD`    | Optional parameter used to set a new password in Active Directory.        |
 
+> [!NOTE]
+> When you omit the optional parameter UpdateAD because the password has previously changed in Active Directory, you also need to omit OldPassword.
+
 
 ### Run Set-AzureStackLCMUserPassword cmdlet
 

--- a/azure-local/manage/manage-secrets-rotation.md
+++ b/azure-local/manage/manage-secrets-rotation.md
@@ -34,7 +34,7 @@ The `Set-AzureStackLCMUserPassword` cmdlet takes the following parameters:
 |`UpdateAD`    | Optional parameter used to set a new password in Active Directory.        |
 
 > [!NOTE]
-> When you omit the optional parameter UpdateAD because the password has previously changed in Active Directory, you also need to omit OldPassword.
+> When you omit the optional parameter `UpdateAD` because the password has previously changed in Active Directory, you also need to omit `OldPassword`.
 
 
 ### Run Set-AzureStackLCMUserPassword cmdlet


### PR DESCRIPTION
Clarified instructions regarding the optional UpdateAD parameter and its relation to OldPassword.

Currently if you don't use optional parameter UpdateAD, you will error out. 

Set-AzureStackLCMUserPassword : Parameter set cannot be resolved using the specified named parameters.

Needs to be made clear in the doc that OldPassword cant also be used in this scenario.